### PR TITLE
Swap +new Date for new Date().getTime()

### DIFF
--- a/comparisons/utils/now/ie8.js
+++ b/comparisons/utils/now/ie8.js
@@ -1,1 +1,1 @@
-+new Date
+new Date().getTime()


### PR DESCRIPTION
+new Date is 44% slower and not explicit in it's functionality.
