### PR TITLE
Display can be set to empty string.

### DIFF
--- a/index.html
+++ b/index.html
@@ -228,7 +228,7 @@ fadeIn(el)
             <div data-browser="ie8" class="browser ie8">
               <h4>IE8+</h4>
               <div class="code-block language-javascript">
-                <pre><code>el.style.display = 'block' // or 'inline', etc.
+                <pre><code>el.style.display = '' // sets default display for el - 'block', 'inline' etc.
 </code></pre>
               </div>
             </div>


### PR DESCRIPTION
Setting display to empty string will apply default display - "inline", "block", "table", "table-cell" etc.
