### PR TITLE
Fixes for the siblings comparison.

### DIFF
--- a/comparisons/elements/siblings/ie8.js
+++ b/comparisons/elements/siblings/ie8.js
@@ -1,4 +1,4 @@
-var siblings = el.parentNode.children()
+var siblings = Array.prototype.slice.call(el.parentNode.children)
 
 for (var i = siblings.length; i--;) {
   if (siblings[i] === el) {

--- a/comparisons/elements/siblings/ie9.js
+++ b/comparisons/elements/siblings/ie9.js
@@ -1,0 +1,5 @@
+var siblings = Array.prototype.slice.call(el.parentNode.children)
+
+siblings.filter(function(child){
+    return child !== el
+})


### PR DESCRIPTION
The children property is not a function, and the property is a NodeList, not an Array, so we need to slice it to get an Array [1]. In IE9, we can simplify things a bit by not re-implementing Array.prototype.filter [2].

Caveats:
1. I don't have access to IE8 or IE9 to actually test this code, so I've only tested it in Chrome.
2. I haven't accounted for [MDN's note](https://developer.mozilla.org/en-US/docs/Web/API/ParentNode.children) that "Internet Explorer 6, 7 and 8 supported it, but erroneously includes Comment nodes."  This could be done by replacing IE8's for loop with this:

``` js
for (var i = siblings.length; i--;) {
  if (siblings[i] === el || siblings[i].nodeType === Node.COMMENT_NODE) {
    siblings.splice(i, 1)
  }
}
```

`nodeType` and `Node.COMMENT_NODE` appear to be defined in [DOM Level 1](http://www.w3.org/TR/REC-DOM-Level-1/level-one-core.html), so I'm guessing this will work in IE8.

[1] https://developer.mozilla.org/en-US/docs/Web/API/ParentNode.children
[2] http://kangax.github.io/es5-compat-table/#Array.prototype.filter
