### PR TITLE
Fixes `map` implementation for IE8+

### DIFF
--- a/comparisons/utils/map/ie8.js
+++ b/comparisons/utils/map/ie8.js
@@ -1,6 +1,8 @@
 function map(arr, fn){
+  var results = [];
   for (var i=0; i < arr.length; i++)
-    fn(arr[i], i);
+    results.push(fn(arr[i], i));
+  return results;
 }
 
 map(array, function(value, index){


### PR DESCRIPTION
`map` is not used for side-affects, you have to return an array of the results of calling fn for each element in the input array (i.e. `map :: (a -> b) -> [a] -> [b]`).
