### PR TITLE
Fixed missing `var` in `parseHTML`

### DIFF
--- a/index.html
+++ b/index.html
@@ -786,7 +786,7 @@ el.nextElementSibling || nextElementSibling(el)
               <h4>IE8+</h4>
               <div class="code-block language-javascript">
                 <pre><code>parseHTML = function(str) {
-  el = document.createElement('div')
+  var el = document.createElement('div')
   el.innerHTML = str
   return el.children
 }


### PR DESCRIPTION
The current example for `parseHTML` introduces a global leak by not using a `var` for its `el`. This fixes that.

I apologize for the trailing line break edit. GItHub's editor decided that was a good idea =/

http://youmightnotneedjquery.com/#parse_html
