### PR TITLE
fixing deep extending onto object

### DIFF
--- a/index.html
+++ b/index.html
@@ -1339,9 +1339,10 @@ forEach(function(item, i){
 
     for (key in obj) {
       if (obj.hasOwnProperty(key)) {
-        if (typeof obj[key] === 'object')
+        if (typeof obj[key] === 'object') {
+          if (!out[key]) out[key] = {}
           deepExtend(out[key], obj[key])
-        else
+        } else
           out[key] = obj[key]
       }
     }


### PR DESCRIPTION
use case is for things like `deepExtend({},{a:{b:1}})` ... 

w/o the fix, undefined is passed in as "out" if the obj does not already have the key that it should be extended with
