### PR TITLE
Security: Mitigate DOM XSS vulnerability

### DIFF
--- a/comparisons/utils/parse_html/ie8.js
+++ b/comparisons/utils/parse_html/ie8.js
@@ -1,7 +1,9 @@
-function (str) {
-  var tmp = document.implementation.createHTMLDocument();
-  tmp.body.innerHTML = str;
-  return tmp.body.children
-}
+var parseHTML = function(str) {
+  var tmp = new ActiveXObject('htmlfile');
+  tmp.open();
+  tmp.write(str);
+  tmp.close();
+  return tmp.body.children;
+};
 
-parseHTML(htmlString)
+parseHTML(htmlString);

--- a/comparisons/utils/parse_html/ie8.js
+++ b/comparisons/utils/parse_html/ie8.js
@@ -1,3 +1,4 @@
+// This version is save, but uses ActiveX
 var parseHTML = function(str) {
   var tmp = new ActiveXObject('htmlfile');
   tmp.open();
@@ -5,5 +6,12 @@ var parseHTML = function(str) {
   tmp.close();
   return tmp.body.children;
 };
+
+// This version is prone to DOM XSS, only use with caution!
+var parseHTML = function(str) {
+  var el = document.createElement('div');
+  el.innerHTML = str;
+  return el.children;
+}
 
 parseHTML(htmlString);

--- a/comparisons/utils/parse_html/ie8.js
+++ b/comparisons/utils/parse_html/ie8.js
@@ -1,7 +1,7 @@
-parseHTML = function(str) {
-  var el = document.createElement('div')
-  el.innerHTML = str
-  return el.children
+function (str) {
+  var tmp = document.implementation.createHTMLDocument();
+  tmp.body.innerHTML = str;
+  return tmp.body.children
 }
 
 parseHTML(htmlString)

--- a/comparisons/utils/parse_html/ie9.js
+++ b/comparisons/utils/parse_html/ie9.js
@@ -1,0 +1,7 @@
+var parseHTML = function(str) {
+  var tmp = document.implementation.createHTMLDocument();
+  tmp.body.innerHTML = str;
+  return tmp.body.children;
+};
+
+parseHTML(htmlString);


### PR DESCRIPTION
Your version of the script is prone to DOM XSS attacks:
`parseHTML('<img src=x onerror=alert(1)>')` will execute the script immediately. This altered version prevents the execution of the script.

`$.parseHTML('<img src=x onerror=alert(1)>')` is still vulnerable to this attack, so generally it's not recommended to parse arbitrary HTML on the client side.
