### PR TITLE
Change "what jQuery does for you" link into a github repo

### DIFF
--- a/jade/index.jade
+++ b/jade/index.jade
@@ -41,7 +41,7 @@ body
           | you might not need anything more than what the browser ships with.
 
         p
-          | At the very least, make sure you know what <a href="https://docs.google.com/document/d/1LPaPA30bLUB_publLIMF0RlhdnPx_ePXm7oW02iiT6o">jQuery is doing for you</a>, and what it's not.  Some developers believe that jQuery
+          | At the very least, make sure you know <a href="https://github.com/gregsabo/whatjquerydoesforyou/blob/master/README.md">what jQuery is doing for you</a>, and what it's not.  Some developers believe that jQuery
           | is protecting us from a great demon of browser incompatibility when, in truth, post-IE8, browsers are pretty easy to
           | deal with on their own.
 


### PR DESCRIPTION
@rwaldron @jdalton @paulirish

May I suggest that we host your list of bugs on Github? Using Google Docs makes it more difficult for others to add to and improve it. I've created a new repo called "whatjquerydoesforyou" to demonstrate what I mean,  and I've ported the content from the original note into Markdown format:

https://github.com/gregsabo/whatjquerydoesforyou/blob/master/README.md

If you like, feel free to move the README into a repo of your own since it's all your content.
