### PR TITLE
Fixing a typo in the previous element sibling code

### DIFF
--- a/br/index.html
+++ b/br/index.html
@@ -1056,14 +1056,14 @@ function prevElementSibling(el) {
   return el;
 }
 
-el.prevElementSibling || prevElementSibling(el);
+el.previousElementSibling || prevElementSibling(el);
 </code></pre>
               </div>
             </div>
             <div data-browser="ie9" class="browser ie9">
               <h4>IE9+</h4>
               <div data-lang="javascript" class="code-block language-javascript">
-                <pre><code>el.prevElementSibling
+                <pre><code>el.previousElementSibling
 </code></pre>
               </div>
             </div>


### PR DESCRIPTION
There is no el.prevElementSibling. The right property is el.previousElementSibling.
