### PR TITLE
Fix syntax error in matches selector for IE8

### DIFF
--- a/comparisons/elements/matches_selector/ie8.js
+++ b/comparisons/elements/matches_selector/ie8.js
@@ -8,8 +8,9 @@ var matches = function(el, selector) {
     for (var i = nodes.length; i--;)
       if (nodes[i] === el) {
         return true;
-    }
+      }
     return false;
+  }
 }
 
 matches(el, '.my-class');


### PR DESCRIPTION
A curly bracket was missing.
