### PR TITLE
Missing post request headers

### DIFF
--- a/comparisons/ajax/post/ie8.js
+++ b/comparisons/ajax/post/ie8.js
@@ -1,4 +1,4 @@
 var request = new XMLHttpRequest();
 request.open('POST', '/my/url', true);
-request.setRequestHeader( "Content-Type", "application/x-www-form-urlencoded; charset=UTF-8" );
+request.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8');
 request.send(data);

--- a/comparisons/ajax/post/ie8.js
+++ b/comparisons/ajax/post/ie8.js
@@ -1,3 +1,4 @@
 var request = new XMLHttpRequest();
 request.open('POST', '/my/url', true);
+request.setRequestHeader( "Content-Type", "application/x-www-form-urlencoded; charset=UTF-8" );
 request.send(data);


### PR DESCRIPTION
When data is sent to the server without a correct headers,
PHP is not making this data available in `$_POST` global variable.
