### PR TITLE
use `.call` to give similar behavior between addEventListener and attachEvent

### DIFF
--- a/comparisons/events/on/ie8.js
+++ b/comparisons/events/on/ie8.js
@@ -2,7 +2,9 @@ function addEventListener(el, eventName, handler) {
   if (el.addEventListener) {
     el.addEventListener(eventName, handler);
   } else {
-    el.attachEvent('on' + eventName, handler);
+    el.attachEvent('on' + eventName, function(){
+      handler.call(el);
+    });
   }
 }
 


### PR DESCRIPTION
Handlers added using `addEventListener` set the value of `this` to the element (`el` in the example) while `attachEvent` sets `this` to `window` which makes it completely useless. Using `.call` here makes `attachEvent` behave like `addEventListener` so that this code behaves as expected.

see http://quirksmode.org/dom/events/
