### PR TITLE
fixed bug on not checking for array in key

### DIFF
--- a/index.html
+++ b/index.html
@@ -1677,7 +1677,7 @@ forEach(array, function(item, i){
 
     for (var key in obj) {
       if (obj.hasOwnProperty(key)) {
-        if (typeof obj[key] === 'object')
+        if (typeof obj[key] === 'object' && obj[key].isArray === false)
           deepExtend(out[key], obj[key]);
         else
           out[key] = obj[key];


### PR DESCRIPTION
If we run into an array when checking the value of the key, we should write to out. Using typeof obj[key] === 'object' isn't sufficient here, because arrays return 'object' as well. 

To make sure the value of the key isn't an array, we can use either Array.isArray or Object.prototype.toString.call. I chose the first because it is easier to understand the intent. 

To replicate bug, you can use the following objects as a test case:

objA = {
    name: 'osvaldo',
    nicknames: ['ozzy', 'ozzinator'],
    contact: {
        email: 'osvaldo.t.mendoza@gmail.com',
        phone: {
            areacode: '212',
            number: {
                first: '200',
                second: '2000'
            }
        }
    }
};

objB = {
    hobbies: ['football', 'cooking'],
    city: {
        name: 'NYC',
        zip: '10001'
    }
};

newObj = deepExtend({}, objA, objB);
console.log(newObj);
