### PR TITLE
Fix double quote string

### DIFF
--- a/comparisons/utils/type/ie8.js
+++ b/comparisons/utils/type/ie8.js
@@ -1,1 +1,1 @@
-Object.prototype.toString.call(obj).replace(/^\[object (.+)\]$/, "$1").toLowerCase();
+Object.prototype.toString.call(obj).replace(/^\[object (.+)\]$/, '$1').toLowerCase();


### PR DESCRIPTION
Unlike the other comparisons single quotes were used for a string.
