### PR TITLE
Add ftdomdelegate as an Event Delegation alternative - #55

### DIFF
--- a/comparisons/events/alternatives.txt
+++ b/comparisons/events/alternatives.txt
@@ -1,0 +1,1 @@
+ftdomdelegate: https://github.com/ftlabs/ftdomdelegate


### PR DESCRIPTION
There was an issue - "Is there a way to achieve event delegation without jQuery? #55".

We created **[ftdomdelegate](https://github.com/ftlabs/ftdomdelegate)** for exactly this.  Associated write up: [DOM Event Delegation without jQuery](https://mattandre.ws/2014/08/small-beautiful-dom-delegation/).

I don't know if you'd like to include it or not, but if you do here's a pull request :smile: 
