### PR TITLE
Fix class removal for IE8+

### DIFF
--- a/comparisons/elements/remove_class/ie8.js
+++ b/comparisons/elements/remove_class/ie8.js
@@ -1,4 +1,4 @@
 if (el.classList)
   el.classList.remove(className);
 else
-  el.className = el.className.replace(new RegExp('(^|\\b)' + className.split(' ').join('|') + '(\\b|$)', 'gi'), ' ');
+  el.className = el.className.replace(new RegExp('(^|\\b)' + el.className.split(' ').join('|') + '(\\b|$)', 'gi'), ' ');


### PR DESCRIPTION
I haven't tested this, but I'm assuming global `className` is a mistake.
