### PR TITLE
Events -> Ready code not working on IE8

### DIFF
--- a/comparisons/events/ready/ie8.js
+++ b/comparisons/events/ready/ie8.js
@@ -3,7 +3,7 @@ function ready(fn) {
     document.addEventListener('DOMContentLoaded', fn);
   } else {
     document.attachEvent('onreadystatechange', function() {
-      if (document.readyState === 'interactive')
+      if (document.readyState === 'interactive' || document.readyState === 'complete')
         fn();
     });
   }


### PR DESCRIPTION
Hi there,

The "on load" callback wasn't getting run in my simple test and it was because `readyState` was straight to `complete` and there's no `interactive`. That's on IE8.

Be good to have some discussion regarding whether the callback could get called twice if `readyState` does get to `interactive` and then `complete`.  If yes, then we'd want to discuss the best code for this.
