### PR TITLE
Update index.html -> Fix an Problem for IE8 on $.ready()

### DIFF
--- a/index.html
+++ b/index.html
@@ -1497,7 +1497,7 @@ addEventListener(el, eventName, handler);
     document.addEventListener('DOMContentLoaded', fn);
   } else {
     document.attachEvent('onreadystatechange', function() {
-      if (document.readyState === 'interactive')
+      if (document.readyState === 'interactive' || document.readyState === 'complete')
         fn();
     });
   }


### PR DESCRIPTION
After document.readyState 'interactive' follows 'complete'. If the page loads so fast that we miss the state interactive the old version will never execute the callback. So we must check for complete in addition.
