### PR TITLE
Offset document.body.scrollTop deprecated

### DIFF
--- a/comparisons/elements/offset/ie8.js
+++ b/comparisons/elements/offset/ie8.js
@@ -1,6 +1,11 @@
-var rect = el.getBoundingClientRect()
-
-{
-  top: rect.top + document.body.scrollTop,
-  left: rect.left + document.body.scrollLeft
+function offset(el){
+	var rect = el.getBoundingClientRect();
+	var scrollTop = window.pageYOffset || document.documentElement.scrollTop,
+		scrollLeft = window.pageXOffset || document.documentElement.scrollLeft;
+	return {
+		top: rect.top + scrollTop,
+		left: rect.left + scrollLeft
+	};
 }
+
+offset(el).top;


### PR DESCRIPTION
document.body.scrollTop is deprecated in ES5 strict-mode for some
browsers (returns zero), so this would be the right way to do it.
