### PR TITLE
outerHeight with margins IE9 'auto' value fix

### DIFF
--- a/comparisons/elements/outer_height_with_margin/ie8.js
+++ b/comparisons/elements/outer_height_with_margin/ie8.js
@@ -2,7 +2,7 @@ function outerHeight(el){
   var height = el.offsetHeight;
   var style = el.currentStyle || getComputedStyle(el);
 
-  height += parseInt(style.marginTop) || 0 + parseInt(style.marginBottom) || 0;
+  height += (parseInt(style.marginTop) || 0) + (parseInt(style.marginBottom) || 0);
   return height;
 }
 

--- a/comparisons/elements/outer_height_with_margin/ie8.js
+++ b/comparisons/elements/outer_height_with_margin/ie8.js
@@ -2,7 +2,7 @@ function outerHeight(el){
   var height = el.offsetHeight;
   var style = el.currentStyle || getComputedStyle(el);
 
-  height += parseInt(style.marginTop) + parseInt(style.marginBottom);
+  height += (parseInt(style.marginTop) || 0) + (parseInt(style.marginBottom) || 0);
   return height;
 }
 

--- a/comparisons/elements/outer_height_with_margin/ie8.js
+++ b/comparisons/elements/outer_height_with_margin/ie8.js
@@ -2,7 +2,7 @@ function outerHeight(el){
   var height = el.offsetHeight;
   var style = el.currentStyle || getComputedStyle(el);
 
-  height += (parseInt(style.marginTop) || 0) + (parseInt(style.marginBottom) || 0);
+  height += parseInt(style.marginTop) || 0 + parseInt(style.marginBottom) || 0;
   return height;
 }
 

--- a/comparisons/elements/outer_height_with_margin/ie9.js
+++ b/comparisons/elements/outer_height_with_margin/ie9.js
@@ -2,7 +2,7 @@ function outerHeight(el){
   var height = el.offsetHeight;
   var style = getComputedStyle(el);
 
-  height += parseInt(style.marginTop) + parseInt(style.marginBottom);
+  height += (parseInt(style.marginTop) || 0) + (parseInt(style.marginBottom) || 0);
   return height;
 }
 

--- a/comparisons/elements/outer_height_with_margin/ie9.js
+++ b/comparisons/elements/outer_height_with_margin/ie9.js
@@ -2,7 +2,7 @@ function outerHeight(el){
   var height = el.offsetHeight;
   var style = getComputedStyle(el);
 
-  height += (parseInt(style.marginTop) || 0) + (parseInt(style.marginBottom) || 0);
+  height += parseInt(style.marginTop) + parseInt(style.marginBottom);
   return height;
 }
 


### PR DESCRIPTION
When margin is set to auto (margin:auto) my IE9 returned 'auto' as a
value so parseInt was NaN, so the function returned NaN. This way
returned value will be zero as it should.
