### PR TITLE
Update AJAX options

### DIFF
--- a/comparisons/ajax/alternatives.txt
+++ b/comparisons/ajax/alternatives.txt
@@ -1,3 +1,3 @@
-ajax: https://github.com/ForbesLindesay/ajax
-request: https://github.com/then/request
 reqwest: https://github.com/ded/Reqwest
+then-request: https://github.com/then/request
+superagent: https://github.com/visionmedia/superagent


### PR DESCRIPTION
`ajax` was last updated in 2013 and was at 0.0.2 and not on npm.
`request` was renamed (?) to `then-request`.
`superagent` is super common these days.

Things are in alphabetical order. Because. :smile: 

Thanks for building this site!
