### PR TITLE
fix for ie8 regex in removeClass

### DIFF
--- a/comparisons/elements/remove_class/ie8.js
+++ b/comparisons/elements/remove_class/ie8.js
@@ -1,4 +1,4 @@
 if (el.classList)
   el.classList.remove(className);
 else
-  el.className = el.className.replace(new RegExp('(^|\\b)(\\s+)' + className.split(' ').join('(\\s+)|(\\s+)') + '(\\s+)(\\b|$)', 'g'), ' ');
+  el.className = el.className.replace(new RegExp('(^|\\b)(\\s*)' + className.split(' ').join('(\\s*)|(\\s*)') + '(\\s*)(\\b|$)', 'g'), ' ');

--- a/comparisons/elements/remove_class/ie8.js
+++ b/comparisons/elements/remove_class/ie8.js
@@ -1,4 +1,4 @@
 if (el.classList)
   el.classList.remove(className);
 else
-  el.className = el.className.replace(new RegExp('(^|\\b)(\\s+)' + className.split(' ').join('(\\s+)|(\\s+)') + '(\\s+)(\\b|$|\s+$)', 'g'), ' ');
+  el.className = el.className.replace(new RegExp('(^|\\b)(\\s+)' + className.split(' ').join('(\\s+)|(\\s+)') + '(\\s+)(\\b|$)', 'g'), ' ');

--- a/comparisons/elements/remove_class/ie8.js
+++ b/comparisons/elements/remove_class/ie8.js
@@ -1,4 +1,4 @@
 if (el.classList)
   el.classList.remove(className);
 else
-  el.className = el.className.replace(new RegExp('(^|\\b)' + className.split(' ').join('|') + '(\\b|$)', 'gi'), ' ');
+  el.className = el.className.replace(new RegExp('(^|\\b)(\\s+)' + className.split(' ').join('(\\s+)|(\\s+)') + '(\\s+)(\\b|$|\s+$)', 'g'), ' ');


### PR DESCRIPTION
This changes solves two issues
- Multiple whitespaces inserted while removing first or the last classname when addClass and removeClass are used one after another, not necessarily toggling a particular className.
- Classnames are case-sensitive as per [W3C](http://www.w3.org/TR/html401/struct/global.html#h-7.5.2)
