### PR TITLE
Update removeClass fallback for ie8

### DIFF
--- a/comparisons/elements/remove_class/ie8.js
+++ b/comparisons/elements/remove_class/ie8.js
@@ -1,4 +1,4 @@
 if (el.classList)
   el.classList.remove(className);
 else
-  el.className = el.className.replace(new RegExp('(^|\\b)(\\s+)' + className.split(' ').join('(\\s+)|(\\s+)') + '(\\s+)(\\b|$)', 'g'), ' ');
+  el.className = el.className.replace(new RegExp('(^|\\b)(\\s*)' + className.split(' ').join('(\\s*)|(\\s*)') + '(\\s*)(\\b|$)', 'g'), ' ');

--- a/comparisons/elements/remove_class/ie8.js
+++ b/comparisons/elements/remove_class/ie8.js
@@ -1,4 +1,10 @@
 if (el.classList)
   el.classList.remove(className);
 else
-  el.className = el.className.replace(new RegExp('(^|\\b)(\\s*)' + className.split(' ').join('(\\s*)|(\\s*)') + '(\\s*)(\\b|$)', 'g'), ' ');
+  el.className = el.className.replace(
+      new RegExp( '(^|\\s)('
+        + className.split( \s ).join( '|' ).replace( /\|{2,}/gm , '|' )
+        + ')(\\s|$)' , 'gm'
+      )
+      , ' '
+  ).join( ' ' ).replace( /(^\s+)|(\s{2,})|(\s+$)/gm , '' );

--- a/comparisons/elements/remove_class/ie8.js
+++ b/comparisons/elements/remove_class/ie8.js
@@ -1,4 +1,4 @@
 if (el.classList)
   el.classList.remove(className);
 else
-  el.className = el.className.replace(new RegExp('(^|\\b)(\\s+)' + className.split(' ').join('(\\s+)|(\\s+)') + '(\\s+)(\\b|$|\s+$)', 'g'), ' ');
+  el.className = el.className.replace(new RegExp('(^|\\b)(\\s+)' + className.split(' ').join('(\\s+)|(\\s+)') + '(\\s+)(\\b|$)', 'g'), ' ');

--- a/comparisons/elements/remove_class/ie8.js
+++ b/comparisons/elements/remove_class/ie8.js
@@ -1,4 +1,4 @@
 if (el.classList)
   el.classList.remove(className);
 else
-  el.className = el.className.replace(new RegExp('(^|\\b)' + className.split(' ').join('|') + '(\\b|$)', 'gi'), ' ');
+  el.className = el.className.replace(new RegExp('(^|\\b)(\\s+)' + className.split(' ').join('(\\s+)|(\\s+)') + '(\\s+)(\\b|$|\s+$)', 'g'), ' ');


### PR DESCRIPTION
With this update className = 'no-js' no longer removes the 'no-js' part from an element.className that contains 'hey-no-js' .
This update tries to remove exuberant whitespace-characters (without a polyfill), works over multiple lines (in case someone did that) both from el.className & from given className-param.

Pipe-character is not allowed in class-names, right?
