### PR TITLE
Delete "empty/ie9.js"

### DIFF
--- a/comparisons/elements/empty/ie9.js
+++ b/comparisons/elements/empty/ie9.js
@@ -1,1 +1,0 @@
-el.innerHTML = '';


### PR DESCRIPTION
`innerHTML` is slower and dosn't works with SVG
