### PR TITLE
check whether CustomEvent is a function 

### DIFF
--- a/comparisons/events/trigger_custom/ie9.js
+++ b/comparisons/events/trigger_custom/ie9.js
@@ -1,4 +1,4 @@
-if (window.CustomEvent) {
+if (window.CustomEvent && typeof window.CustomEvent === 'function') {
   var event = new CustomEvent('my-event', {detail: {some: 'data'}});
 } else {
   var event = document.createEvent('CustomEvent');


### PR DESCRIPTION
IE9, 10 and 11 have the window.CustomEvent property but not as a function and thus throw an error when called
