### PR TITLE
IE9+ changes readyState prematurely

### DIFF
--- a/index.html
+++ b/index.html
@@ -1511,7 +1511,7 @@ addEventListener(el, eventName, handler);
               <h4>IE9+</h4>
               <div data-lang="javascript" class="code-block language-javascript">
                 <pre><code>function ready(fn) {
-  if (document.readyState != 'loading'){
+  if (document.attachEvent ? document.readyState === "complete" : document.readyState !== "loading"){
     fn();
   } else {
     document.addEventListener('DOMContentLoaded', fn);


### PR DESCRIPTION
Modify readyState example to handle IE9+ changing readyState before DOM is ready.

See pull request: https://github.com/jquery/jquery/pull/901

References issue #175 