### PR TITLE
parseHTML - createHTMLDocument required parameter fix

### DIFF
--- a/br/index.html
+++ b/br/index.html
@@ -1849,7 +1849,7 @@ parseHTML(htmlString);
               <h4>IE9+</h4>
               <div data-lang="javascript" class="code-block language-javascript">
                 <pre><code>var parseHTML = function(str) {
-  var tmp = document.implementation.createHTMLDocument();
+  var tmp = document.implementation.createHTMLDocument('');
   tmp.body.innerHTML = str;
   return tmp.body.children;
 };

--- a/comparisons/utils/parse_html/ie9.js
+++ b/comparisons/utils/parse_html/ie9.js
@@ -1,7 +1,7 @@
 var parseHTML = function(str) {
-	var tmp = document.implementation.createHTMLDocument('');
-	tmp.body.innerHTML = str;
-	return tmp.body.children;
+  var tmp = document.implementation.createHTMLDocument('');
+  tmp.body.innerHTML = str;
+  return tmp.body.children;
 };
 
 parseHTML(htmlString);

--- a/comparisons/utils/parse_html/ie9.js
+++ b/comparisons/utils/parse_html/ie9.js
@@ -1,7 +1,7 @@
 var parseHTML = function(str) {
-  var tmp = document.implementation.createHTMLDocument();
-  tmp.body.innerHTML = str;
-  return tmp.body.children;
+	var tmp = document.implementation.createHTMLDocument('');
+	tmp.body.innerHTML = str;
+	return tmp.body.children;
 };
 
 parseHTML(htmlString);

--- a/index.html
+++ b/index.html
@@ -1887,7 +1887,7 @@ parseHTML(htmlString);
               <h4>IE9+</h4>
               <div data-lang="javascript" class="code-block language-javascript">
                 <pre><code>var parseHTML = function(str) {
-  var tmp = document.implementation.createHTMLDocument();
+  var tmp = document.implementation.createHTMLDocument('');
   tmp.body.innerHTML = str;
   return tmp.body.children;
 };


### PR DESCRIPTION
Not all browsers consider the 'title' parameter for createHTMLDocument to be optional. Passing in a blank string should do the trick given that the title isn't needed for this approach anyways.

Reference here: https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/createHTMLDocument#Browser_compatibility