### PR TITLE
Default to IE 10

### DIFF
--- a/jade/br/index.jade
+++ b/jade/br/index.jade
@@ -60,7 +60,7 @@ body
         label(for="version") Para qual versão do IE você costuma de dar suporte?
 
         .slider
-          input(name="version", type="range", min="8", max="10").version-slider
+          input(name="version", type="range", min="8", max="10", value="10").version-slider
 
           .rule
             .range-label 8

--- a/jade/index.jade
+++ b/jade/index.jade
@@ -67,7 +67,7 @@ body
         label(for="version") What's the oldest version of IE you need to support?
 
         .slider
-          input(name="version", id="version", type="range", min="8", max="10").version-slider
+          input(name="version", id="version", type="range", min="8", max="10", value="10").version-slider
 
           .rule
             .range-label 8


### PR DESCRIPTION
IE has ceased to develop new features in favor of Edge, and the [market share for IE < 11 is just 0.45%](https://caniuse.com/usage-table). The majority of developers today will either not target IE or only target IE 11, so displaying the most modern code we have by default (IE 10) will be significantly more convenient. I personally always manually select IE 10 when using this site.