### PR TITLE
Added support a Arrays

### DIFF
--- a/comparisons/utils/deep_extend/ie8.js
+++ b/comparisons/utils/deep_extend/ie8.js
@@ -9,8 +9,12 @@ var deepExtend = function(out) {
 
     for (var key in obj) {
       if (obj.hasOwnProperty(key)) {
-        if (typeof obj[key] === 'object')
-          out[key] = deepExtend(out[key], obj[key]);
+        if (typeof obj[key] === 'object'){
+          if(obj[key] instanceof Array == true)
+            out[key] = obj[key].slice(0);
+          else
+            out[key] = deepExtend(out[key], obj[key]);
+        }
         else
           out[key] = obj[key];
       }

--- a/comparisons/utils/deep_extend/ie8.js
+++ b/comparisons/utils/deep_extend/ie8.js
@@ -9,7 +9,7 @@ var deepExtend = function(out) {
 
     for (var key in obj) {
       if (obj.hasOwnProperty(key)) {
-        if (typeof obj[key] === 'object')
+        if (typeof obj[key] === 'object' && obj[key] instanceof Array == false)
           out[key] = deepExtend(out[key], obj[key]);
         else
           out[key] = obj[key];


### PR DESCRIPTION
Before that, when you extended a Object with a Array, this array would be converted to a Object.

Code examples
```
objA = { 'myKey': 'myValue', 'myArray': [ 'item' ], 'myObject': { 'foo': 'bar' } };
objB = { 'newKey': 'newValue', 'myArray': [ undefined, 'newItem' ] };

// JS example
deepExtend({}, objA, objB);

// jQuery example
$.extend({}, objA, objB);
```