### PR TITLE
Fix parseHTML not returning Array of all Nodes

### DIFF
--- a/index.html
+++ b/index.html
@@ -2173,7 +2173,7 @@ parseHTML(htmlString);
                 <pre><code>var parseHTML = function(str) {
   var tmp = document.implementation.createHTMLDocument();
   tmp.body.innerHTML = str;
-  return tmp.body.childNodes;
+  return Array.prototype.slice.call(tmp.body.childNodes);
 };
 
 parseHTML(htmlString);

--- a/index.html
+++ b/index.html
@@ -2160,7 +2160,7 @@ map(array, function(value, index){
                 <pre><code>var parseHTML = function(str) {
   var el = document.createElement('div');
   el.innerHTML = str;
-  return el.children;
+  return el.childNodes;
 };
 
 parseHTML(htmlString);
@@ -2173,7 +2173,7 @@ parseHTML(htmlString);
                 <pre><code>var parseHTML = function(str) {
   var tmp = document.implementation.createHTMLDocument();
   tmp.body.innerHTML = str;
-  return tmp.body.children;
+  return tmp.body.childNodes;
 };
 
 parseHTML(htmlString);


### PR DESCRIPTION
`el.children` works upon elements only, and `el.childNodes` on nodes including non-element nodes like text and comment nodes. The latter is the behaviour of `jQuery`.

I.e. before this fix `parseHTML("foo<p>do</p>bar")` would return an `HTMLCollection` with only the `p` element, and `$.parseHTML("foo<p>do</p>bar")` returns an `Array` of length 3 containing `[#text, p, #text]`.

So to fix this let `parseHTML` use `.childNodes` and convert it to an `Array`.

This would work on IE9+, on IE8 though you would manually need to convert the `NodeList` returned by `el.childNodes` to an `Array` if you require that.