### PR TITLE
Fix the result from .index() replacement

### DIFF
--- a/comparisons/elements/index/ie8.js
+++ b/comparisons/elements/index/ie8.js
@@ -1,9 +1,9 @@
 function index(el) {
   if (!el) return -1;
   var i = 0;
-  do {
-    if (el.nodeType === 1) i++;
+  while (el) {
     el = el.previousSibling;
-  } while (el);
+    if (el && el.nodeType === 1) i++;
+  }
   return i;
 }

--- a/comparisons/elements/index/ie9.js
+++ b/comparisons/elements/index/ie9.js
@@ -1,8 +1,8 @@
 function index(el) {
   if (!el) return -1;
   var i = 0;
-  do {
+  while (el = el.previousElementSibling) {
     i++;
-  } while (el = el.previousElementSibling);
+  }
   return i;
 }


### PR DESCRIPTION
I found when attempting to use the `.index()` replacement that the index was off by 1.
The error was because the `do {}` part of the loop was executing the `i++` before the condition was evaluated meaning the result is always at-least `1`. 

This is wrong as the first element should have an index of `0`.

Here's a JSFiddle showing the before/after and with the jQuery version as a reference.
https://jsfiddle.net/yck52avu/1/