### PR TITLE
Fixed element removal from dom

### DIFF
--- a/comparisons/elements/remove/ie8.js
+++ b/comparisons/elements/remove/ie8.js
@@ -1,1 +1,3 @@
-el.parentNode.removeChild(el);
+if(el.parentNode != null) {
+  el.parentNode.removeChild(el);
+}

--- a/comparisons/elements/remove/ie8.js
+++ b/comparisons/elements/remove/ie8.js
@@ -1,3 +1,3 @@
-if(el.parentNode != null) {
+if (el.parentNode !== null) {
   el.parentNode.removeChild(el);
 }


### PR DESCRIPTION
parent node of element can be null, for elements created dynamically and still not part of the tree, as you can also see in the [polyfill](https://developer.mozilla.org/en-US/docs/Web/API/ChildNode/remove) on MDN