### PR TITLE
Add empty string title fix for IE11

### DIFF
--- a/src/comparisons/utils/parse_html/ie9.js
+++ b/src/comparisons/utils/parse_html/ie9.js
@@ -1,5 +1,5 @@
-var parseHTML = function(str) {
-  var tmp = document.implementation.createHTMLDocument();
+var parseHTML = function (str) {
+  var tmp = document.implementation.createHTMLDocument("");
   tmp.body.innerHTML = str;
   return tmp.body.children;
 };


### PR DESCRIPTION
Fixes #184 and #93 

The title argument is not optional on IE11 so we pass in an empty string here