### PR TITLE
Add multiple class support to removeClass

### DIFF
--- a/src/comparisons/elements/remove_class/ie8.js
+++ b/src/comparisons/elements/remove_class/ie8.js
@@ -1,4 +1,12 @@
-if (el.classList)
-  el.classList.remove(className);
-else
-  el.className = el.className.replace(new RegExp('(^|\\b)' + className.split(' ').join('|') + '(\\b|$)', 'gi'), ' ');
+function removeClass(el, className) {
+  var classes = className.split(' ');
+  for (var i = 0; i < classes.length; i++) {
+    if (el.classList) {
+      el.classList.remove(classes[i]);
+    } else {
+      el.className = el.className
+        .replace(new RegExp('(?:^|\\s)' + classes[i] + '(?:\\s|$)'), ' ')
+        .trim();
+    }
+  }
+}

--- a/src/comparisons/elements/remove_class/ie8.js
+++ b/src/comparisons/elements/remove_class/ie8.js
@@ -6,7 +6,7 @@ function removeClass(el, className) {
     } else {
       el.className = el.className
         .replace(new RegExp('(?:^|\\s)' + classes[i] + '(?:\\s|$)'), ' ')
-        .trim();
+        .replace(new RegExp(/^\s+|\s+$/g), '');
     }
   }
 }


### PR DESCRIPTION
Fixes #35 

The previous implementation:
1. Does not support multiple classes for removal
  a. If you were to remove `a b` from `a b cab`, the `b` would get removed from the `cab` class, resulting in `   ca `
2. Does not handle hypens correctly 
  a. If className is `hello-there hello-there-friend`, removing `hello-there` would yield a final className of `-friend`