### PR TITLE
Add version option for ie11

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A resource for doing things _au naturel_.
 
 ## Contributing
 
-To add a new section, just create a folder for it, and add `jquery.js`, and `ie8.js`, `ie9.js` and `ie10.js` as needed. For example, if you have `ie8.js` and `ie9.js`, the ie9 version will be shown to people looking for a solution that works in ie9 or 10.
+To add a new section, just create a folder for it, and add `jquery.js`, and `ie8.js`, `ie9.js`, `ie10.js` and `ie11.js` as needed. For example, if you have `ie8.js` and `ie9.js`, the ie9 version will be shown to people looking for a solution that works in ie9, 10 or 11.
 
 ## Building
 

--- a/src/coffee/index.coffee
+++ b/src/coffee/index.coffee
@@ -15,7 +15,7 @@ hide = (els...) ->
   for el in els when el
     el.style.display = 'none'
 
-setMinVersion = (version=10) ->
+setMinVersion = (version=11) ->
   version = parseInt version
 
   for section in document.querySelectorAll('.comparison')
@@ -34,6 +34,9 @@ setMinVersion = (version=10) ->
         hide versions['ie10']
       when 10
         showFirst versions['ie10'], versions['ie9'], versions['ie8']
+        hide versions['ie11']
+      when 11
+        showFirst versions['ie11'], versions['ie10'], versions['ie9'], versions['ie8']
 
 filter = (term) ->
   visibleIndex = 0

--- a/src/jade/index.jade
+++ b/src/jade/index.jade
@@ -60,12 +60,13 @@ body
         label(for="version") What's the oldest version of IE you need to support?
 
         .slider
-          input(name="version", id="version", type="range", min="8", max="10", value="10").version-slider
+          input(name="version", id="version", type="range", min="8", max="11", value="11").version-slider
 
           .rule
             .range-label 8
             .range-label 9
             .range-label 10
+            .range-label 11
 
     .comparisons
 
@@ -91,7 +92,7 @@ body
                 if co.alternatives
                   +alternatives(co.alternatives.txt)
 
-                for browser in ['jquery', 'ie8', 'ie9', 'ie10']
+                for browser in ['jquery', 'ie8', 'ie9', 'ie10', 'ie11']
                   if co[browser]
                     .browser(data-browser=getNamePart(browser), class=getNamePart(browser))
 

--- a/src/styl/index.styl
+++ b/src/styl/index.styl
@@ -238,21 +238,18 @@ header.search
       outline none
 
   .field
-    position relative
+    display flex
+    margin-bottom 1.5em
 
     label
-      padding-right 10em
+      padding-right 1em
       font-size 1.1em
-      padding-top 0em
-      padding-bottom 3em
       display block
+      flex-grow 1
 
     .slider
-      position absolute
-      top 0
-      right 0
       width 10em
-      height 2em
+      flex-shrink 0
 
 .hidden
   display none
@@ -326,7 +323,7 @@ input[type='range']
   background-color #F0F0F0
   height 30px
   width 100%
-  padding 4px
+  padding 0 14px
 
 input[type='range']::-webkit-slider-thumb
   -webkit-appearance none !important
@@ -337,17 +334,14 @@ input[type='range']::-webkit-slider-thumb
   border-radius 5px
   background-color #fcfcfc
 
+.rule {
+  display flex
+}
+
 .range-label
-  float left
   width 33%
   text-align center
   padding 0 4px
-
-.range-label:first-of-type
-  text-align left
-
-.range-label:last-of-type
-  text-align right
 
 footer
   margin 3em auto


### PR DESCRIPTION
This pull request adds an option for ie11 to the version selection slider. As far as I can tell, this should also enable `ie11.js` files to be recognized.

Closes #221 