### PR TITLE
Add $.on example with descendent event handler delegates

### DIFF
--- a/src/comparisons/events/on/ie9.js
+++ b/src/comparisons/events/on/ie9.js
@@ -1,1 +1,15 @@
-el.addEventListener(eventName, eventHandler);
+function addEventListener(el, eventName, eventHandler, selector) {
+  if (selector) {
+    el.addEventListener(eventName, function (e) {
+      if (e.target && e.target.matches(selector)) {
+        eventHandler(e);
+      }
+    });
+  } else {
+    el.addEventListener(eventName, eventHandler);
+  }
+}
+
+addEventListener(el, eventName, eventHandler);
+// Or when you want to delegate event handling
+addEventListener(el, eventName, eventHandler, selector);

--- a/src/comparisons/events/on/jquery.js
+++ b/src/comparisons/events/on/jquery.js
@@ -1,1 +1,3 @@
 $(el).on(eventName, eventHandler);
+// Or when you want to delegate event handling
+$(el).on(eventName, selector, eventHandler);


### PR DESCRIPTION
The `$.on` event handler is neat because it allows you to subscribe to descendant elements that might not already exist. This PR adds a bit of extra code to handle a selector in case the user wants to target descendants.

Closes out #179