### PR TITLE
Run builds on each push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+on: [push]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build application
+        run: npm run build
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          retention-days: 3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,4 +21,10 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
+          name: build-artifacts
+          path: |
+            index.html
+            css/*
+            js/*
+            br/*
           retention-days: 3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Download all workflow run artifacts
         uses: actions/download-artifact@v3
+        with:
+          name: build-artifacts
 
       - name: Stage build artifacts
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,17 +9,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '14'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm install
-
-      - name: Build application
-        run: npm run build
+      - name: Download all workflow run artifacts
+        uses: actions/download-artifact@v3
 
       - name: Stage build artifacts
         run: |

--- a/src/readTree.js
+++ b/src/readTree.js
@@ -20,8 +20,9 @@ function get(cb) {
         if (typeof comp !== 'string') {
           for (const [filename, code] of Object.entries(comp)) {
             const [version, ext] = filename.split('.');
-
-            out[title][name][version] ||= {};
+            if (!out[title][name][version]) {
+              out[title][name][version] = {};
+            }
             out[title][name][version][ext] = code;
           }
         } else {


### PR DESCRIPTION
**Context:**
Builds aren't executing on each push so it's difficult to validate that changes are not breaking until they hit the `dev` branch. This PR enables builds on each push, and publishing only on `dev`