### PR TITLE
Add ES6 slider option

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.{js,css}]
+charset = utf-8

--- a/src/comparisons/ajax/json/es6.js
+++ b/src/comparisons/ajax/json/es6.js
@@ -1,0 +1,1 @@
+const data = await (await fetch('/my/url')).json();

--- a/src/comparisons/effects/alternatives.txt
+++ b/src/comparisons/effects/alternatives.txt
@@ -1,3 +1,3 @@
-animate.css: https://daneden.github.io/animate.css/
+animate.css: https://animate.style
 move.js: https://github.com/visionmedia/move.js
 velocity.js: https://julian.com/research/velocity/

--- a/src/jade/index.jade
+++ b/src/jade/index.jade
@@ -1,12 +1,12 @@
 doctype html
 
 //- This will go into the HTML file to let people know to edit this file instead:
-// Please edit the index.jade or the files in comparisons/, this file is generated
+// Please edit the src/jade/index.jade or the files in comparisons/, this file is generated
 
 include _alternatives
 
-<!--[if lt IE 10 ]> <html class="old-ie"> <![endif]-->
-<!--[if (gt IE 9)|!(IE)]><!--> <html> <!--<![endif]-->
+<!--[if gt IE 5]> <html class="old-ie"> <![endif]-->
+<!--[if !(IE)]><!--> <html> <!--<![endif]-->
 head
   meta(charset='utf-8')
   meta(http-equiv='X-UA-Compatible', content='chrome=1')
@@ -31,7 +31,7 @@ body
           | You might <span class="highlighted">no</span>t need <span class="highlighted">jQuery</span>
 
       .old-ie-message
-        | You certainly can support IE 9 and below without jQuery, but we don't.  Please stop messing with us.
+        | You certainly can support IE 11 and below without jQuery, but this site does not.
 
     .explanation
       .inner
@@ -46,7 +46,7 @@ body
         p
           | At the very least, make sure you know what <a href="https://docs.google.com/document/d/1LPaPA30bLUB_publLIMF0RlhdnPx_ePXm7oW02iiT6o">jQuery is doing for you</a>, and what it's not.  Some developers believe that jQuery
           | is protecting us from a great demon of browser incompatibility when, in truth, post-IE8, browsers are pretty easy to
-          | deal with on their own.
+          | deal with on their own; and after the Internet Explorer error, the browsers do even more.
 
     .share-buttons
       a.share-button-github(href="https://github.com/HubSpot/YouMightNotNeedjQuery")
@@ -61,13 +61,14 @@ body
         label(for="version") What's the oldest version of IE you need to support?
 
         .slider
-          input(name="version", id="version", type="range", min="8", max="11", value="11").version-slider
+          input(name="version", id="version", type="range", min="8", max="12", value="12").version-slider
 
           .rule
             .range-label 8
             .range-label 9
             .range-label 10
             .range-label 11
+            .range-label N/A
 
     .comparisons
 
@@ -93,7 +94,7 @@ body
                 if co.alternatives
                   +alternatives(co.alternatives.txt)
 
-                for browser in ['jquery', 'ie8', 'ie9', 'ie10', 'ie11']
+                for browser in ['jquery', 'ie8', 'ie9', 'ie10', 'ie11', 'es6']
                   if co[browser]
                     .browser(data-browser=getNamePart(browser), class=getNamePart(browser))
 
@@ -152,3 +153,4 @@ body
   script(type='text/javascript', src='https://platform.twitter.com/widgets.js')
 
   div(style='-webkit-transform: translateZ(0);')
+<!-- --> </html> <!-- -->

--- a/src/jade/index.jade
+++ b/src/jade/index.jade
@@ -46,7 +46,7 @@ body
         p
           | At the very least, make sure you know what <a href="https://docs.google.com/document/d/1LPaPA30bLUB_publLIMF0RlhdnPx_ePXm7oW02iiT6o">jQuery is doing for you</a>, and what it's not.  Some developers believe that jQuery
           | is protecting us from a great demon of browser incompatibility when, in truth, post-IE8, browsers are pretty easy to
-          | deal with on their own; and after the Internet Explorer error, the browsers do even more.
+          | deal with on their own; and after the Internet Explorer era, the browsers do even more.
 
     .share-buttons
       a.share-button-github(href="https://github.com/HubSpot/YouMightNotNeedjQuery")

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,5 +1,5 @@
-const VERSION_OPTIONS = [8, 9, 10, 11];
-const DEFAULT_VERSION = 11;
+const VERSION_OPTIONS = [8, 9, 10, 11, 12];
+const DEFAULT_VERSION = 12;
 
 function numberWithCommas(num) {
   return num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
@@ -37,7 +37,7 @@ function hide(...els) {
 
 function setMinVersion(version = DEFAULT_VERSION) {
   version = parseInt(version);
-  setQueryString('ie' + version.toString())
+  setQueryString(version)
 
   for (const section of document.querySelectorAll('.comparison')) {
     const blocks = section.querySelectorAll('.browser');
@@ -52,15 +52,15 @@ function setMinVersion(version = DEFAULT_VERSION) {
     switch (version) {
       case 8:
         showFirst(versions['ie8']);
-        hide(versions['ie9'], versions['ie10'], versions['ie11']);
+        hide(versions['ie9'], versions['ie10'], versions['ie11'], versions['es6']);
         break;
       case 9:
         showFirst(versions['ie9'], versions['ie8']);
-        hide(versions['ie10'], versions['ie11']);
+        hide(versions['ie10'], versions['ie11'], versions['es6']);
         break;
       case 10:
         showFirst(versions['ie10'], versions['ie9'], versions['ie8']);
-        hide(versions['ie11']);
+        hide(versions['ie11'], versions['es6']);
         break;
       case 11:
         showFirst(
@@ -69,6 +69,16 @@ function setMinVersion(version = DEFAULT_VERSION) {
           versions['ie9'],
           versions['ie8']
         );
+        hide(versions['es6']);
+        break;
+      case 12:
+        showFirst(
+          versions['es6'],
+          versions['ie11'],
+          versions['ie10'],
+          versions['ie9'],
+          versions['ie8']
+        )
         break;
     }
   }
@@ -110,7 +120,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const slider = document.querySelector('.version-slider');
 
-  const parsedSliderState = parseInt(getInitialSliderState()?.replace('ie', ''));
+  const parsedSliderState = getInitialSliderState();
   if (VERSION_OPTIONS.includes(parsedSliderState)) {
     slider.value = parsedSliderState;
   } else {

--- a/src/js/queryString.js
+++ b/src/js/queryString.js
@@ -1,10 +1,22 @@
 function setQueryString(supportedVersion) {
+  let supportedVersionStr = 'ie' + supportedVersion.toString();
+  if (supportedVersion === 12) {
+    supportedVersionStr = 'es6';
+  }
+
   const urlParams = new URLSearchParams(location.search);
-  urlParams.set('support', supportedVersion);
+  urlParams.set('support', supportedVersionStr);
   history.replaceState({}, '', '?' + urlParams);
 }
 
 function getInitialSliderState() {
   const urlParams = new URLSearchParams(location.search);
-  return urlParams.get('support');
+  let supportVersionStr = urlParams.get('support');
+  let supportVersion = 12;
+  if (supportVersionStr === 'es6') {
+    supportVersion = 12;
+  } else if (supportVersionStr && supportVersionStr.indexOf('ie') === 0) {
+    supportVersion = parseInt(supportVersionStr.substring(2));
+  }
+  return supportVersion;
 }

--- a/src/styl/index.styl
+++ b/src/styl/index.styl
@@ -323,7 +323,7 @@ input[type='range']
   background-color #F0F0F0
   height 30px
   width 100%
-  padding 0 14px
+  padding 0 8px
 
 input[type='range']::-webkit-slider-thumb
   -webkit-appearance none !important


### PR DESCRIPTION
Add an option for ES6 slider -- can think of other things to rename to though (some keywords such as `await` didn't arrive until ES2016 or later).

Fixes the main issue in #222 but only implements one comparison example (JSON) as a demonstration.

Tested that old-ie message should display, but didn't test it on an actual Internet Explorer browser.

I didn't go ahead and drop the differences between various IE versions into a dropdown or anything like that.  I figure that this can be a later refactor once there's enough content to go there.  Will continue to discuss on #222 