### PR TITLE
Disable duplicate build job on non-dev pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,8 @@
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - dev
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
On branches from within this repo, both `push` and `pull_request` are fired. We only want `push` GHA triggers to run on dev