### PR TITLE
$.contains selector

### DIFF
--- a/src/comparisons/elements/contains_selector/alternatives.txt
+++ b/src/comparisons/elements/contains_selector/alternatives.txt
@@ -1,0 +1,1 @@
+xpath: https://www.w3schools.com/xml/xpath_intro.asp

--- a/src/comparisons/elements/contains_selector/ie8.js
+++ b/src/comparisons/elements/contains_selector/ie8.js
@@ -1,1 +1,0 @@
-!!el.querySelector(selector);

--- a/src/comparisons/elements/contains_selector/jquery.js
+++ b/src/comparisons/elements/contains_selector/jquery.js
@@ -1,1 +1,1 @@
-$(el).find(selector).length;
+$("div:contains('my text')");

--- a/src/comparisons/elements/contains_selector/modern.js
+++ b/src/comparisons/elements/contains_selector/modern.js
@@ -1,0 +1,3 @@
+[...document.querySelectorAll('div')].filter((el) =>
+  el.textContent.includes('my text')
+);

--- a/src/comparisons/elements/find_selector/ie8.js
+++ b/src/comparisons/elements/find_selector/ie8.js
@@ -1,0 +1,1 @@
+!!el.querySelector(selector);

--- a/src/comparisons/elements/find_selector/jquery.js
+++ b/src/comparisons/elements/find_selector/jquery.js
@@ -1,0 +1,1 @@
+$(el).find(selector).length;


### PR DESCRIPTION
Closes #232. We already had an implementation listed under `contains_selector` but that's actually an implementation for plain ol' find with a boolean check on the end. Moved that over, and added Xpath as an alternative