### PR TITLE
Replace parseInt -> parseFloat for margin-based examples

### DIFF
--- a/src/comparisons/elements/outer_height_with_margin/ie8.js
+++ b/src/comparisons/elements/outer_height_with_margin/ie8.js
@@ -2,7 +2,7 @@ function outerHeight(el) {
   var height = el.offsetHeight;
   var style = el.currentStyle || getComputedStyle(el);
 
-  height += parseInt(style.marginTop) + parseInt(style.marginBottom);
+  height += parseFloat(style.marginTop) + parseFloat(style.marginBottom);
   return height;
 }
 

--- a/src/comparisons/elements/outer_height_with_margin/ie9.js
+++ b/src/comparisons/elements/outer_height_with_margin/ie9.js
@@ -2,7 +2,7 @@ function outerHeight(el) {
   var height = el.offsetHeight;
   var style = getComputedStyle(el);
 
-  height += parseInt(style.marginTop) + parseInt(style.marginBottom);
+  height += parseFloat(style.marginTop) + parseFloat(style.marginBottom);
   return height;
 }
 

--- a/src/comparisons/elements/outer_height_with_margin/modern.js
+++ b/src/comparisons/elements/outer_height_with_margin/modern.js
@@ -3,8 +3,8 @@ function outerHeight(el) {
 
   return (
     el.getBoundingClientRect().height +
-    Number.parseFloat(style.getPropertyValue('marginTop')) +
-    Number.parseFloat(style.getPropertyValue('marginBottom'))
+    parseFloat(style.getPropertyValue('marginTop')) +
+    parseFloat(style.getPropertyValue('marginBottom'))
   );
 }
 

--- a/src/comparisons/elements/outer_width_with_margin/ie8.js
+++ b/src/comparisons/elements/outer_width_with_margin/ie8.js
@@ -2,7 +2,7 @@ function outerWidth(el) {
   var width = el.offsetWidth;
   var style = el.currentStyle || getComputedStyle(el);
 
-  width += parseInt(style.marginLeft) + parseInt(style.marginRight);
+  width += parseFloat(style.marginLeft) + parseFloat(style.marginRight);
   return width;
 }
 

--- a/src/comparisons/elements/outer_width_with_margin/ie9.js
+++ b/src/comparisons/elements/outer_width_with_margin/ie9.js
@@ -2,7 +2,7 @@ function outerWidth(el) {
   var width = el.offsetWidth;
   var style = getComputedStyle(el);
 
-  width += parseInt(style.marginLeft) + parseInt(style.marginRight);
+  width += parseFloat(style.marginLeft) + parseFloat(style.marginRight);
   return width;
 }
 

--- a/src/comparisons/elements/outer_width_with_margin/modern.js
+++ b/src/comparisons/elements/outer_width_with_margin/modern.js
@@ -3,8 +3,8 @@ function outerWidth(el) {
 
   return (
     el.getBoundingClientRect().width +
-    Number.parseFloat(style.getPropertyValue('marginLeft')) +
-    Number.parseFloat(style.getPropertyValue('marginRight'))
+    parseFloat(style.getPropertyValue('marginLeft')) +
+    parseFloat(style.getPropertyValue('marginRight'))
   );
 }
 


### PR DESCRIPTION
Called out by #213 but I wanted to update the old examples to use `parseFloat` too