### PR TITLE
Add button to copy snippets

### DIFF
--- a/src/components/CodeBlock.astro
+++ b/src/components/CodeBlock.astro
@@ -1,0 +1,91 @@
+---
+import {Prism} from '@astrojs/prism';
+
+export interface Props {
+  lang?: string;
+  code?: string;
+}
+
+const {lang, code} = Astro.props as Props;
+---
+
+<div class="code-wrapper">
+  <button title="Copy code snippet" class="copy-code">📋</button>
+  {code && <Prism class="code" lang={lang} code={code} />}
+</div>
+
+<style lang="scss">
+  .code-wrapper {
+    position: relative;
+  }
+
+  button {
+    position: absolute;
+    top: 0;
+    right: 0;
+    opacity: 0.2;
+    cursor: pointer;
+    background: #eee;
+    border: 1px solid transparent;
+    padding: 6px;
+
+    &:hover {
+      opacity: 1;
+      border-color: #ccc;
+    }
+  }
+</style>
+
+<script>
+  function oldCopyText(text: string) {
+    const textArea = document.createElement('textarea');
+    textArea.value = text;
+    textArea.style.top = '0';
+    textArea.style.left = '0';
+    textArea.style.position = 'fixed'; // Avoids scrolling on focus
+    document.body.appendChild(textArea);
+    textArea.focus();
+    textArea.select();
+
+    try {
+      document.execCommand('copy');
+    } finally {
+      document.body.removeChild(textArea);
+    }
+  }
+
+  function copyText(text: string) {
+    if (!navigator.clipboard) {
+      oldCopyText(text);
+      return;
+    }
+    navigator.clipboard.writeText(text).catch(() => {
+      oldCopyText(text);
+    });
+  }
+
+  const buttonElements = document.querySelectorAll('.copy-code');
+  buttonElements.forEach((el) => {
+    el.setAttribute('data-label', el.innerHTML);
+    el.addEventListener('click', (event) => {
+      const currentEl = event.target as HTMLElement;
+      const pre = currentEl.nextElementSibling;
+      if (pre) {
+        copyText(pre.textContent);
+        const range = document.createRange();
+        range.selectNode(pre);
+        getSelection().removeAllRanges();
+        getSelection().addRange(range);
+        currentEl.innerHTML = 'Copied!';
+        setTimeout(() => {
+          currentEl.innerHTML = currentEl.getAttribute('data-label');
+        }, 1000);
+      } else {
+        currentEl.innerHTML = 'Failed to copy :(';
+        setTimeout(() => {
+          currentEl.innerHTML = currentEl.getAttribute('data-label');
+        }, 1000);
+      }
+    });
+  });
+</script>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,6 @@
 ---
-import {Prism} from '@astrojs/prism';
 import classNames from '@sindresorhus/class-names';
+import CodeBlock from '../components/CodeBlock.astro';
 import getNewestEngine from '../lib/newest-engine';
 import getComparisons from '../lib/comparisons';
 import isEven from '../utils/is-even';
@@ -207,16 +207,9 @@ const comparisons = await getComparisons();
                                     engineName.startsWith('ie') ? '+' : ''
                                   }`}
                                 </h4>
-                                {allCode.map(
-                                  ({language, code}) =>
-                                    code && (
-                                      <Prism
-                                        class="code"
-                                        lang={language}
-                                        code={code}
-                                      />
-                                    )
-                                )}
+                                {allCode.map(({language, code}) => (
+                                  <CodeBlock lang={language} code={code} />
+                                ))}
                               </div>
                             )
                           )}


### PR DESCRIPTION
**Context:**
I had this idea while developing this project. I wanted to reference one of the snippets on the page but got annoyed with manual copy + paste. It's so easy to hook into the clipboard, so let's offer a button for the users to press. The code snippet should instantly be loaded into clipboard, and the snippet itself highlighted for maximum indication of what has been copied.

**Preview:**
![0772be0f4f16adadbe0de5ff03c32dc8](https://user-images.githubusercontent.com/10366495/190553595-f44152ea-da29-4ac7-bb5a-93c70725b4da.gif)
