### PR TITLE
Add escape mechanism for detaching event handlers

### DIFF
--- a/src/comparisons/events/on/ie8.js
+++ b/src/comparisons/events/on/ie8.js
@@ -1,11 +1,15 @@
 function addEventListener(el, eventName, handler) {
   if (el.addEventListener) {
     el.addEventListener(eventName, handler);
+    return handler;
   } else {
-    el.attachEvent('on' + eventName, function () {
-      handler.call(el);
-    });
+    var wrappedHandler = function (event) {
+      handler.call(el, event);
+    };
+    el.attachEvent('on' + eventName, wrappedHandler);
+    return wrappedHandler;
   }
 }
 
-addEventListener(el, eventName, handler);
+// Use the return value to remove that event listener, see #off
+var handlerToRemove = addEventListener(el, eventName, handler);

--- a/src/comparisons/events/on/ie9.js
+++ b/src/comparisons/events/on/ie9.js
@@ -1,15 +1,19 @@
 function addEventListener(el, eventName, eventHandler, selector) {
   if (selector) {
-    el.addEventListener(eventName, function (e) {
+    var wrappedHandler = function (e) {
       if (e.target && e.target.matches(selector)) {
         eventHandler(e);
       }
-    });
+    };
+    el.addEventListener(eventName, wrappedHandler);
+    return wrappedHandler;
   } else {
     el.addEventListener(eventName, eventHandler);
+    return eventHandler;
   }
 }
 
+// Use the return value to remove that event listener, see #off
 addEventListener(el, eventName, eventHandler);
 // Or when you want to delegate event handling
 addEventListener(el, eventName, eventHandler, selector);

--- a/src/comparisons/events/on/modern.js
+++ b/src/comparisons/events/on/modern.js
@@ -13,6 +13,7 @@ function addEventListener(el, eventName, eventHandler, selector) {
   }
 }
 
+// Use the return value to remove that event listener, see #off
 addEventListener(el, eventName, eventHandler);
 // Or when you want to delegate event handling
 addEventListener(el, eventName, eventHandler, selector);

--- a/src/comparisons/events/on/modern.js
+++ b/src/comparisons/events/on/modern.js
@@ -1,12 +1,15 @@
 function addEventListener(el, eventName, eventHandler, selector) {
   if (selector) {
-    el.addEventListener(eventName, (e) => {
+    const wrappedHandler = (e) => {
       if (e.target && e.target.matches(selector)) {
         eventHandler(e);
       }
-    });
+    };
+    el.addEventListener(eventName, wrappedHandler);
+    return wrappedHandler;
   } else {
     el.addEventListener(eventName, eventHandler);
+    return eventHandler;
   }
 }
 


### PR DESCRIPTION
Fixes #104--the concept is to suggest that the return value of calling `addEventListener` is what should be fed as the "handler" to `removeEventListener`