### PR TITLE
Fix up trigger examples to fire native actions

### DIFF
--- a/src/comparisons/events/trigger_native/ie8.js
+++ b/src/comparisons/events/trigger_native/ie8.js
@@ -1,7 +1,18 @@
-if (document.createEvent) {
-  var event = document.createEvent('HTMLEvents');
-  event.initEvent('change', true, false);
-  el.dispatchEvent(event);
-} else {
-  el.fireEvent('onchange');
+function trigger(el, eventType) {
+  if (typeof eventType === 'string' && typeof el[eventType] === 'function') {
+    el[eventType]();
+  } else if (eventType === 'string') {
+    if (document.createEvent) {
+      var event = document.createEvent('HTMLEvents');
+      event.initEvent(eventType, true, false);
+      el.dispatchEvent(event);
+    } else {
+      el.fireEvent('on' + eventType);
+    }
+  } else {
+    el.dispatchEvent(eventType);
+  }
 }
+
+// For a full list of event types: https://developer.mozilla.org/en-US/docs/Web/API/document.createEvent
+trigger(el, 'focus');

--- a/src/comparisons/events/trigger_native/ie9.js
+++ b/src/comparisons/events/trigger_native/ie9.js
@@ -4,7 +4,7 @@ function trigger(el, eventType) {
   } else {
     var event;
     if (eventType === 'string') {
-      document.createEvent('HTMLEvents');
+      event = document.createEvent('HTMLEvents');
       event.initEvent(eventType, true, false);
     } else {
       event = eventType;

--- a/src/comparisons/events/trigger_native/ie9.js
+++ b/src/comparisons/events/trigger_native/ie9.js
@@ -1,4 +1,17 @@
+function trigger(el, eventType) {
+  if (typeof eventType === 'string' && typeof el[eventType] === 'function') {
+    el[eventType]();
+  } else {
+    var event;
+    if (eventType === 'string') {
+      document.createEvent('HTMLEvents');
+      event.initEvent(eventType, true, false);
+    } else {
+      event = eventType;
+    }
+    el.dispatchEvent(event);
+  }
+}
+
 // For a full list of event types: https://developer.mozilla.org/en-US/docs/Web/API/document.createEvent
-var event = document.createEvent('HTMLEvents');
-event.initEvent('change', true, false);
-el.dispatchEvent(event);
+trigger(el, 'focus');

--- a/src/comparisons/events/trigger_native/jquery.js
+++ b/src/comparisons/events/trigger_native/jquery.js
@@ -1,1 +1,1 @@
-$(el).trigger('change');
+$(el).trigger('focus');

--- a/src/comparisons/events/trigger_native/modern.js
+++ b/src/comparisons/events/trigger_native/modern.js
@@ -1,3 +1,15 @@
+function trigger(el, eventType) {
+  if (typeof eventType === 'string' && typeof el[eventType] === 'function') {
+    el[eventType]();
+  } else {
+    const event =
+      eventType === 'string'
+        ? new Event(eventType, {bubbles: true})
+        : eventType;
+    el.dispatchEvent(event);
+  }
+}
+
+trigger(el, 'focus');
 // For a full list of event types: https://developer.mozilla.org/en-US/docs/Web/API/Event
-const event = new Event('change', {bubbles: true});
-el.dispatchEvent(event);
+trigger(el, new PointerEvent('pointerover'));


### PR DESCRIPTION
**Context:**
This should fix _most_ of the concerns raised in #38. There are notable exceptions, however. First, these new snippets do not care for selector-based matching and so it's not firing events across multiple elements. It just takes in an element reference to remain simple. Second, this implementation does not honor namespaced event names just because that would add too much complexity for 99% of use cases.

**Changes:**
- The `trigger` function in all of the trigger native examples will attempt to find and fire any related methods on that element before choosing to dispatch the event. For example, `click` and `focus` will fire respective events same as jQuery does, and it will not attempt emulate event propagation
- Allowed for the `trigger` function to accept event type strings or custom event objects, should the user want to pass in something like a `MouseEvent` or the like, referenced in the #38 issue