### PR TITLE
Add a collapsable sidebar

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,20 +4,7 @@ import CodeBlock from '../components/CodeBlock.astro';
 import getNewestEngine from '../lib/newest-engine';
 import getComparisons from '../lib/comparisons';
 import isEven from '../utils/is-even';
-
-const capsWords = ['JSON', 'HTML', 'AJAX'];
-
-function titleCase(str: string) {
-  return str
-    .replace(
-      /(^|\b)([a-z])([a-z]+)/g,
-      (_match, space, first, rest) => `${space}${first.toUpperCase()}${rest}`
-    )
-    .replace(
-      new RegExp(`(?:^|\b)(${capsWords.join('|')})(?:$|\b)`, 'ig'),
-      (_match, word) => word.toUpperCase()
-    );
-}
+import titleCase from '../utils/title-case';
 
 const comparisons = await getComparisons();
 ---
@@ -42,195 +29,236 @@ const comparisons = await getComparisons();
     <link rel="stylesheet" href="/prism.min.css" />
   </head>
   <body>
-    <div id="top">
-      <header id="top-header">
-        <h1 class="title">You might not need jQuery</h1>
-      </header>
-      <article class="explanation">
-        <p>
-          jQuery and its cousins are great, and by all means use them if it
-          makes it easier to develop your application.
-          <br /><br />
-          If you're developing a library on the other hand, please take a moment
-          to consider if you actually need jQuery as a dependency. Maybe you can
-          include a few lines of utility code, and forgo the requirement. If you're
-          only targeting more modern browsers, you might not need anything more than
-          what the browser ships with.
-          <br /><br />
-          At the very least, make sure you know what <a
-            href="https://docs.google.com/document/d/1LPaPA30bLUB_publLIMF0RlhdnPx_ePXm7oW02iiT6o"
-            >jQuery is doing for you</a
-          >, and what it's not. Some developers believe that jQuery is
-          protecting us from a great demon of browser incompatibility when, in
-          truth, post-IE8, browsers are pretty easy to deal with on their own;
-          and after the Internet Explorer era, the browsers do even more.
-        </p>
-      </article>
-      <address class="share-buttons">
-        <a
-          href="https://github.com/HubSpot/YouMightNotNeedjQuery"
-          class="share-button-github"
-        >
-          <span class="share-button-github-message">★ Star on Github</span>
-          <span class="github-stars"></span>
-        </a>
-      </address>
-      <nav>
-        <input
-          id="search"
-          type="text"
-          role="searchbox"
-          placeholder="Search..."
-          required
-        />
-        <div class="input-box">
-          <label for="ie-question">Do you need to support IE?</label>
-          <input type="checkbox" id="ie-question" name="ie-question" />
-        </div>
-        <div id="ie-version-box" class="input-box hidden">
-          <label for="ie-min-version"
-            >What's the oldest version of IE you need to support?</label
-          >
-          <div class="slider">
-            <input
-              type="range"
-              id="ie-min-version"
-              name="ie-min-version"
-              min={8}
-              max={11}
-              value={11}
-            />
-            <table class="slider-labels" aria-hidden={true}>
-              <tr>
-                {
-                  [8, 9, 10, 11].map((version) => (
-                    <td class="slider-label ie-slider-label">{version}</td>
-                  ))
-                }
-              </tr>
-
-
-            </table>
-          </div>
-        </div>
+    <div class="main-wrapper">
+      <nav id="sidebar">
+        <ul class="sidebar-categories">
+          {
+            Object.entries(comparisons).map(([categoryName, category]) => (
+              <li class="sidebar-category">
+                <a href={`#${categoryName}`}>{titleCase(categoryName)}</a>
+                <ul class="sidebar-comparisons">
+                  {Object.keys(category.comparisons).map((comparisonName) => (
+                    <li class="sidebar-comparison">
+                      <a href={`#${comparisonName}`}>
+                        {titleCase(comparisonName.replaceAll('_', ' '))}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </li>
+            ))
+          }
+        </ul>
       </nav>
-    </div>
-
-    <main id="comparisons">
-      <div class="empty-message">Your search didn't match any comparisons.</div>
-
-      <div class="categories">
-        {
-          Object.entries(comparisons).map(([categoryName, category], index) => (
-            <section
-              class={classNames('category', {
-                even: isEven(index)
-              })}
-              id={categoryName}
+      <main id="main-content">
+        <div id="top">
+          <header id="top-header">
+            <h1 class="title">You might not need jQuery</h1>
+          </header>
+          <article class="explanation">
+            <p>
+              jQuery and its cousins are great, and by all means use them if it
+              makes it easier to develop your application.
+              <br /><br />
+              If you're developing a library on the other hand, please take a moment
+              to consider if you actually need jQuery as a dependency. Maybe you
+              can include a few lines of utility code, and forgo the requirement.
+              If you're only targeting more modern browsers, you might not need anything
+              more than what the browser ships with.
+              <br /><br />
+              At the very least, make sure you know what <a
+                href="https://docs.google.com/document/d/1LPaPA30bLUB_publLIMF0RlhdnPx_ePXm7oW02iiT6o"
+                >jQuery is doing for you</a
+              >, and what it's not. Some developers believe that jQuery is
+              protecting us from a great demon of browser incompatibility when,
+              in truth, post-IE8, browsers are pretty easy to deal with on their
+              own; and after the Internet Explorer era, the browsers do even
+              more.
+            </p>
+          </article>
+          <address class="share-buttons">
+            <a
+              href="https://github.com/HubSpot/YouMightNotNeedjQuery"
+              class="share-button-github"
             >
-              <header class="comparisons-header">
-                <h2 class="category-name">
-                  <a href={`#${categoryName}`}>{titleCase(categoryName)}</a>
-                </h2>
-                {category.alternatives && (
-                  <div class="alternatives">
-                    <h4 class="alternatives-title">Alternatives:</h4>
-                    <ul class="alternatives-list">
-                      {Object.entries(category.alternatives).map(
-                        ([alternativeName, alternativeUrl]) => (
-                          <li>
-                            <a
-                              href={alternativeUrl}
-                              target="_blank"
-                              rel="noopener"
-                              class="alternative-link"
-                            >
-                              {alternativeName}
-                            </a>
-                          </li>
-                        )
-                      )}
-                    </ul>
-                  </div>
-                )}
-              </header>
-              <div class="category-comparisons">
-                {Object.entries(category.comparisons).map(
-                  ([comparisonName, comparison]) => {
-                    const newestEngine = getNewestEngine(
-                      Object.keys(comparison.engines)
-                    );
+              <span class="share-button-github-message">★ Star on Github</span>
+              <span class="github-stars"></span>
+            </a>
+          </address>
+          <nav>
+            <input
+              id="search"
+              type="text"
+              role="searchbox"
+              placeholder="Search..."
+              required
+            />
+            <div class="input-box">
+              <label for="ie-question">Do you need to support IE?</label>
+              <input type="checkbox" id="ie-question" name="ie-question" />
+            </div>
+            <div id="ie-version-box" class="input-box hidden">
+              <label for="ie-min-version"
+                >What's the oldest version of IE you need to support?</label
+              >
+              <div class="slider">
+                <input
+                  type="range"
+                  id="ie-min-version"
+                  name="ie-min-version"
+                  min={8}
+                  max={11}
+                  value={11}
+                />
+                <table class="slider-labels" aria-hidden={true}>
+                  <tr>
+                    {
+                      [8, 9, 10, 11].map((version) => (
+                        <td class="slider-label ie-slider-label">{version}</td>
+                      ))
+                    }
+                  </tr>
 
-                    return (
-                      <div class="comparison" id={comparisonName}>
-                        <header class="comparisons-header">
-                          <h3 class="comparison-title">
-                            <a href={`#${comparisonName}`}>
-                              {titleCase(comparisonName.replaceAll('_', ' '))}
-                            </a>
-                          </h3>
-                          {comparison.alternatives && (
-                            <div class="alternatives">
-                              <h4 class="alternatives-title">Alternatives:</h4>
-                              <ul class="alternatives-list">
-                                {Object.entries(comparison.alternatives).map(
-                                  ([alternativeName, alternativeUrl]) => (
-                                    <li>
-                                      <a
-                                        href={alternativeUrl}
-                                        target="_blank"
-                                        rel="noopener"
-                                        class="alternative-link"
-                                      >
-                                        {alternativeName}
-                                      </a>
-                                    </li>
+
+                </table>
+              </div>
+            </div>
+          </nav>
+        </div>
+
+        <article id="comparisons">
+          <div class="empty-message">
+            Your search didn't match any comparisons.
+          </div>
+
+          <div class="categories">
+            {
+              Object.entries(comparisons).map(
+                ([categoryName, category], index) => (
+                  <section
+                    class={classNames('category', {
+                      even: isEven(index)
+                    })}
+                    id={categoryName}
+                  >
+                    <header class="comparisons-header">
+                      <h2 class="category-name">
+                        <a href={`#${categoryName}`}>
+                          {titleCase(categoryName)}
+                        </a>
+                      </h2>
+                      {category.alternatives && (
+                        <div class="alternatives">
+                          <h4 class="alternatives-title">Alternatives:</h4>
+                          <ul class="alternatives-list">
+                            {Object.entries(category.alternatives).map(
+                              ([alternativeName, alternativeUrl]) => (
+                                <li>
+                                  <a
+                                    href={alternativeUrl}
+                                    target="_blank"
+                                    rel="noopener"
+                                    class="alternative-link"
+                                  >
+                                    {alternativeName}
+                                  </a>
+                                </li>
+                              )
+                            )}
+                          </ul>
+                        </div>
+                      )}
+                    </header>
+                    <div class="category-comparisons">
+                      {Object.entries(category.comparisons).map(
+                        ([comparisonName, comparison]) => {
+                          const newestEngine = getNewestEngine(
+                            Object.keys(comparison.engines)
+                          );
+
+                          return (
+                            <div class="comparison" id={comparisonName}>
+                              <header class="comparisons-header">
+                                <h3 class="comparison-title">
+                                  <a href={`#${comparisonName}`}>
+                                    {titleCase(
+                                      comparisonName.replaceAll('_', ' ')
+                                    )}
+                                  </a>
+                                </h3>
+                                {comparison.alternatives && (
+                                  <div class="alternatives">
+                                    <h4 class="alternatives-title">
+                                      Alternatives:
+                                    </h4>
+                                    <ul class="alternatives-list">
+                                      {Object.entries(
+                                        comparison.alternatives
+                                      ).map(
+                                        ([alternativeName, alternativeUrl]) => (
+                                          <li>
+                                            <a
+                                              href={alternativeUrl}
+                                              target="_blank"
+                                              rel="noopener"
+                                              class="alternative-link"
+                                            >
+                                              {alternativeName}
+                                            </a>
+                                          </li>
+                                        )
+                                      )}
+                                    </ul>
+                                  </div>
+                                )}
+                              </header>
+                              <div class="engines">
+                                {Object.entries(comparison.engines).map(
+                                  ([engineName, allCode]) => (
+                                    <div
+                                      class={classNames('engine', {
+                                        hidden:
+                                          engineName !== newestEngine &&
+                                          engineName !== 'jquery'
+                                      })}
+                                      data-engine={engineName}
+                                    >
+                                      <h4 class="engine-name">
+                                        {`${engineName}${
+                                          engineName.startsWith('ie') ? '+' : ''
+                                        }`}
+                                      </h4>
+                                      {allCode.map(({language, code}) => (
+                                        <CodeBlock
+                                          lang={language}
+                                          code={code}
+                                        />
+                                      ))}
+                                    </div>
                                   )
                                 )}
-                              </ul>
-                            </div>
-                          )}
-                        </header>
-                        <div class="engines">
-                          {Object.entries(comparison.engines).map(
-                            ([engineName, allCode]) => (
-                              <div
-                                class={classNames('engine', {
-                                  hidden:
-                                    engineName !== newestEngine &&
-                                    engineName !== 'jquery'
-                                })}
-                                data-engine={engineName}
-                              >
-                                <h4 class="engine-name">
-                                  {`${engineName}${
-                                    engineName.startsWith('ie') ? '+' : ''
-                                  }`}
-                                </h4>
-                                {allCode.map(({language, code}) => (
-                                  <CodeBlock lang={language} code={code} />
-                                ))}
                               </div>
-                            )
-                          )}
-                        </div>
-                      </div>
-                    );
-                  }
-                )}
-              </div>
-            </section>
-          ))
-        }
-      </div>
-    </main>
+                            </div>
+                          );
+                        }
+                      )}
+                    </div>
+                  </section>
+                )
+              )
+            }
+          </div>
+        </article>
 
-    <footer>
-      <p>
-        Made by <span id="credit-a"></span>, <span id="credit-b"></span> and some
-        engineer gamers at <a href="https://dev.hubspot.com">HubSpot</a>.
-      </p>
-    </footer>
+        <footer>
+          <p>
+            Made by <span id="credit-a"></span>, <span id="credit-b"></span> and
+            some engineer gamers at <a href="https://dev.hubspot.com">HubSpot</a
+            >.
+          </p>
+        </footer>
+      </main>
+    </div>
 
     <style lang="scss">
       @use 'modern-normalize';
@@ -249,6 +277,27 @@ const comparisons = await getComparisons();
 
       .hidden {
         display: none !important;
+      }
+
+      .main-wrapper {
+        width: 100%;
+      }
+
+      #sidebar {
+        flex: 0;
+        width: 300px;
+        position: fixed;
+        left: 0;
+        top: 0;
+        bottom: 0;
+        overflow: auto;
+      }
+
+      #main-content {
+        align-items: center;
+        display: flex;
+        flex-direction: column;
+        margin-left: 300px;
       }
 
       #top {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -283,6 +283,10 @@ const comparisons = await getComparisons();
 
       html {
         scroll-behavior: smooth;
+
+        @media screen and (max-width: $sidebar-collapsed-screen-width) {
+          scroll-padding-top: $mobile-navbar-height;
+        }
       }
 
       body {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -30,6 +30,12 @@ const comparisons = await getComparisons();
   </head>
   <body>
     <div class="main-wrapper">
+      <input id="sidebar-toggle" type="checkbox" />
+      <nav id="mobile-navbar">
+        <label id="sidebar-toggle-label" for="sidebar-toggle">
+          <span></span>
+        </label>
+      </nav>
       <nav id="sidebar">
         <ul class="sidebar-categories">
           {
@@ -267,6 +273,10 @@ const comparisons = await getComparisons();
     <style lang="scss">
       @use 'modern-normalize';
 
+      $sidebar-width: 300px;
+      $sidebar-collapsed-screen-width: 828px;
+      $mobile-navbar-height: 60px;
+
       ::placeholder {
         color: rgba(0, 0, 0, 0.5);
       }
@@ -291,15 +301,92 @@ const comparisons = await getComparisons();
         width: 100%;
       }
 
+      #sidebar-toggle {
+        display: none;
+      }
+
+      #sidebar-toggle:checked ~ #sidebar {
+        left: 0;
+      }
+
+      #sidebar-toggle-label {
+        position: fixed;
+        z-index: 2;
+        top: 28px;
+        left: 20px;
+        width: 26px;
+        height: 26px;
+        cursor: pointer;
+
+        span,
+        span::before,
+        span::after {
+          display: block;
+          position: absolute;
+          width: 100%;
+          height: 2px;
+          background-color: #333;
+          transition-duration: 0.25s;
+        }
+
+        span::before {
+          content: '';
+          top: -8px;
+        }
+
+        span::after {
+          content: '';
+          top: 8px;
+        }
+      }
+
+      #sidebar-toggle:checked + #mobile-navbar {
+        #sidebar-toggle-label span {
+          transform: rotate(45deg);
+          &::before {
+            top: 0;
+            transform: rotate(0deg);
+          }
+          &::after {
+            top: 0;
+            transform: rotate(90deg);
+          }
+        }
+      }
+
+      #mobile-navbar {
+        position: fixed;
+        left: 0;
+        right: 0;
+        background-color: #fff;
+        height: $mobile-navbar-height;
+        border-bottom: 1px solid #eee;
+        z-index: 1;
+        display: none;
+
+        @media screen and (max-width: $sidebar-collapsed-screen-width) {
+          display: block;
+        }
+      }
+
       #sidebar {
         flex: 0;
-        width: 300px;
+        background-color: #fff;
+        z-index: 1;
+        width: $sidebar-width;
         position: fixed;
         left: 0;
         top: 0;
         bottom: 0;
         overflow: auto;
         padding: 2em;
+        transition-duration: 0.25s;
+
+        @media screen and (max-width: $sidebar-collapsed-screen-width) {
+          width: 100%;
+          left: -100%;
+          margin-top: $mobile-navbar-height;
+        }
 
         ul {
           list-style: none;
@@ -345,7 +432,12 @@ const comparisons = await getComparisons();
         align-items: center;
         display: flex;
         flex-direction: column;
-        margin-left: 300px;
+        margin-left: $sidebar-width;
+
+        @media screen and (max-width: $sidebar-collapsed-screen-width) {
+          margin-left: 0;
+          margin-top: $mobile-navbar-height;
+        }
       }
 
       #top {
@@ -861,6 +953,15 @@ const comparisons = await getComparisons();
       );
       const activeCategoryOrComparison = findActiveCategoryOrComparison();
       markSidebarAnchorActive(activeCategoryOrComparison);
+
+      const sidebar: HTMLDivElement = document.querySelector('#sidebar');
+      sidebar.querySelectorAll('a').forEach((el) => {
+        el.addEventListener('click', () => {
+          const sidebarToggle: HTMLInputElement =
+            document.querySelector('#sidebar-toggle');
+          sidebarToggle.checked = false;
+        });
+      });
 
       const numberFormat = new Intl.NumberFormat('en-US');
       const starsText = document.querySelector('.github-stars');

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -311,11 +311,9 @@ const comparisons = await getComparisons();
           color: inherit;
 
           &.active {
-            font-weight: 600;
-
             li,
             div {
-              background: rgba(0, 0, 0, 0.05);
+              background: rgba(0, 0, 0, 0.1);
             }
           }
         }
@@ -334,6 +332,7 @@ const comparisons = await getComparisons();
           .sidebar-category-title,
           .sidebar-comparison-title {
             padding: 4px;
+            font-weight: 300;
 
             &:hover {
               background: rgba(0, 0, 0, 0.05);

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -837,15 +837,16 @@ const comparisons = await getComparisons();
         }
         return anchor;
       }
-      function markSidebarAnchorActive(href: string) {
+      function markSidebarAnchorActive(anchorName?: string) {
         // Clear out active anchors first
         const sidebar: HTMLDivElement = document.querySelector('#sidebar');
         sidebar.querySelectorAll('a').forEach((el) => {
-          if (!el.href.includes(href)) el.classList.remove('active');
+          if (!anchorName || el.href !== `#${anchorName}`)
+            el.classList.remove('active');
         });
-        if (href) {
+        if (anchorName) {
           const maybeAnchor: HTMLAnchorElement | null = sidebar.querySelector(
-            `a[href*=${href}]`
+            `a[href*=${anchorName}]`
           );
           if (maybeAnchor) {
             maybeAnchor.classList.add('active');
@@ -859,6 +860,8 @@ const comparisons = await getComparisons();
           markSidebarAnchorActive(activeCategoryOrComparison);
         }, 100)
       );
+      const activeCategoryOrComparison = findActiveCategoryOrComparison();
+      markSidebarAnchorActive(activeCategoryOrComparison);
 
       const numberFormat = new Intl.NumberFormat('en-US');
       const starsText = document.querySelector('.github-stars');

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -35,14 +35,18 @@ const comparisons = await getComparisons();
           {
             Object.entries(comparisons).map(([categoryName, category]) => (
               <li class="sidebar-category">
-                <a href={`#${categoryName}`}>{titleCase(categoryName)}</a>
+                <a href={`#${categoryName}`}>
+                  <div class="sidebar-category-title">
+                    {titleCase(categoryName)}
+                  </div>
+                </a>
                 <ul class="sidebar-comparisons">
                   {Object.keys(category.comparisons).map((comparisonName) => (
-                    <li class="sidebar-comparison">
-                      <a href={`#${comparisonName}`}>
+                    <a href={`#${comparisonName}`}>
+                      <li class="sidebar-comparison-title">
                         {titleCase(comparisonName.replaceAll('_', ' '))}
-                      </a>
-                    </li>
+                      </li>
+                    </a>
                   ))}
                 </ul>
               </li>
@@ -267,6 +271,10 @@ const comparisons = await getComparisons();
         color: rgba(0, 0, 0, 0.5);
       }
 
+      html {
+        scroll-behavior: smooth;
+      }
+
       body {
         font-family: system-ui, sans-serif;
         line-height: 1.5;
@@ -291,6 +299,47 @@ const comparisons = await getComparisons();
         top: 0;
         bottom: 0;
         overflow: auto;
+        padding: 2em;
+
+        ul {
+          list-style: none;
+          padding-left: 0;
+        }
+
+        a {
+          text-decoration: none;
+          color: inherit;
+
+          &.active {
+            font-weight: 600;
+
+            li,
+            div {
+              background: rgba(0, 0, 0, 0.05);
+            }
+          }
+        }
+
+        .sidebar-category {
+          margin-bottom: 1em;
+
+          .sidebar-category-title {
+            font-size: 20px;
+          }
+
+          .sidebar-comparison-title {
+            color: #666;
+          }
+
+          .sidebar-category-title,
+          .sidebar-comparison-title {
+            padding: 4px;
+
+            &:hover {
+              background: rgba(0, 0, 0, 0.05);
+            }
+          }
+        }
       }
 
       #main-content {
@@ -636,6 +685,7 @@ const comparisons = await getComparisons();
     <script>
       import getNewestEngine from '../lib/newest-engine';
       import isEven from '../utils/is-even';
+      import throttle from '../utils/throttle';
 
       const adamfschwartz = document.createElement('a');
       adamfschwartz.href = 'https://twitter.com/adamfschwartz';
@@ -761,6 +811,54 @@ const comparisons = await getComparisons();
       ieMinVersion.addEventListener('change', () => {
         updateEngines(`ie${ieMinVersion.value}`);
       });
+
+      function findActiveCategoryOrComparison(): string | undefined {
+        let closestElementY = 0;
+        let anchor: string;
+        // First, check category names
+        for (let el of document.querySelectorAll('.category-name')) {
+          const elementY = (el as HTMLElement).offsetTop;
+          if (elementY >= window.scrollY) {
+            closestElementY = elementY;
+            anchor = el.querySelector('a').href.split('#').pop();
+            break;
+          }
+        }
+        for (let el of document.querySelectorAll('.comparison-title')) {
+          const elementY = (el as HTMLElement).offsetTop;
+          const diff = elementY - window.scrollY;
+          const isCloser =
+            diff >= 0 &&
+            (!closestElementY || diff < closestElementY - window.scrollY);
+          if (isCloser) {
+            anchor = el.querySelector('a').href.split('#').pop();
+            break;
+          }
+        }
+        return anchor;
+      }
+      function markSidebarAnchorActive(href: string) {
+        // Clear out active anchors first
+        const sidebar: HTMLDivElement = document.querySelector('#sidebar');
+        sidebar.querySelectorAll('a').forEach((el) => {
+          if (!el.href.includes(href)) el.classList.remove('active');
+        });
+        if (href) {
+          const maybeAnchor: HTMLAnchorElement | null = sidebar.querySelector(
+            `a[href*=${href}]`
+          );
+          if (maybeAnchor) {
+            maybeAnchor.classList.add('active');
+          }
+        }
+      }
+      window.addEventListener(
+        'scroll',
+        throttle(() => {
+          const activeCategoryOrComparison = findActiveCategoryOrComparison();
+          markSidebarAnchorActive(activeCategoryOrComparison);
+        }, 100)
+      );
 
       const numberFormat = new Intl.NumberFormat('en-US');
       const starsText = document.querySelector('.github-stars');

--- a/src/utils/throttle.ts
+++ b/src/utils/throttle.ts
@@ -1,0 +1,30 @@
+/**
+ * Throttle function with a trailing edge.
+ *
+ * @param func function to execute
+ * @param wait time in milliseconds to wait before calling again
+ * @returns
+ */
+export default function throttle(func: () => void, wait: number = 100) {
+  let context: any, args: any;
+  let waiting = false;
+  let doTrailing = false;
+  return function () {
+    context = this;
+    args = arguments;
+    if (!waiting) {
+      func.apply(context, args);
+      waiting = true;
+      window.setTimeout(function () {
+        if (doTrailing) {
+          func.apply(context, args);
+        }
+        waiting = false;
+        doTrailing = false;
+        context = args = null;
+      }, wait);
+    } else {
+      doTrailing = true;
+    }
+  };
+}

--- a/src/utils/title-case.ts
+++ b/src/utils/title-case.ts
@@ -1,0 +1,12 @@
+const capsWords = ['JSON', 'HTML', 'AJAX'];
+
+export default function titleCase(str: string) {
+  return str
+    .replace(
+      /(^|\b)([a-z])([a-z]+)/g,
+      (_match, space, first, rest) => `${space}${first.toUpperCase()}${rest}`
+    )
+    .replace(new RegExp(`(${capsWords.join('|')})`, 'ig'), (_match, word) =>
+      word.toUpperCase()
+    );
+}


### PR DESCRIPTION
**Issue:**
Should close #234 

**Changes:**
- [x] Added a sidebar component that renders every category and comparison
- [x] Smooth scrolling enabled between components
- [x] Active category or comparison is highlighted in the sidebar and updates automatically
- [x] Fixed a small capitalization issue where HTML, JSON, AJAX acronyms were not fully capitalized
- [x] Sidebar collapses automatically and is expandable on mobile screens

**Work out of scope for this PR:**
- There should be a "Back to Top" button
- Comparisons and full categories that are hidden from search should also hide in the sidebar
- If the active category or comparison is out of scroll for the sidebar, the sidebar should scroll with it
- Sidebar, intro, and comparisons should be broken up into separate components and should communicate via a global event bus to avoid the _one massive file_

**Preview:**
|Desktop|
|-|

https://user-images.githubusercontent.com/10366495/191389317-f17e87a7-95bd-4322-bf08-fdbf9b1c4567.mp4

|Mobile|
|-|

https://user-images.githubusercontent.com/10366495/191389348-ba30864e-c609-40e6-ac64-362d11bcae30.mp4