### PR TITLE
Don't evaluate hidden comparisons as active in the sidebar

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -913,14 +913,27 @@ const comparisons = await getComparisons();
         // First, check category names
         for (let el of document.querySelectorAll('.category-name')) {
           const elementY = (el as HTMLElement).offsetTop;
+          // Element is hidden
+          if (elementY === 0) {
+            continue;
+          }
           if (elementY >= window.scrollY) {
             closestElementY = elementY;
             anchor = el.querySelector('a').href.split('#').pop();
             break;
           }
         }
+        // Only check comparison names if we have scrolled. Otherwise, it will show "hidden"
         for (let el of document.querySelectorAll('.comparison-title')) {
           const elementY = (el as HTMLElement).offsetTop;
+          // Don't evaluate nodes beyond the closest category
+          if (elementY > closestElementY) {
+            break;
+          }
+          // Element is hidden
+          if (elementY === 0) {
+            continue;
+          }
           const diff = elementY - window.scrollY;
           const isCloser =
             diff >= 0 &&

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -923,7 +923,6 @@ const comparisons = await getComparisons();
             break;
           }
         }
-        // Only check comparison names if we have scrolled. Otherwise, it will show "hidden"
         for (let el of document.querySelectorAll('.comparison-title')) {
           const elementY = (el as HTMLElement).offsetTop;
           // Don't evaluate nodes beyond the closest category


### PR DESCRIPTION
A bug in the implementation of #305 treats hidden elements (i.e. elements with a scrollTop of 0) as the "closest" elements to that of the scroll position, and marks them as active. This PR fixes that