### PR TITLE
Re-add query parameters for IE versions

### DIFF
--- a/src/lib/newest-engine.ts
+++ b/src/lib/newest-engine.ts
@@ -13,7 +13,10 @@ export default function getNewestEngine(
     return engines[0];
   }
 
-  return engines.find(
-    (engine) => engineOrder.indexOf(engine) <= engineOrder.indexOf(targetEngine)
-  )!;
+  return (
+    engines.find(
+      (engine) =>
+        engineOrder.indexOf(engine) <= engineOrder.indexOf(targetEngine)
+    ) || engines[0]
+  );
 }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -871,7 +871,19 @@ const comparisons = await getComparisons();
         }
       });
 
+      function setQueryString(supportedVersion?: string) {
+        if (supportedVersion) {
+          const urlParams = new URLSearchParams(location.search);
+          urlParams.set('support', supportedVersion);
+          history.replaceState({}, '', '?' + urlParams);
+        } else {
+          history.replaceState({}, '', location.pathname);
+        }
+      }
+
       function updateEngines(targetVersion?: string) {
+        setQueryString(targetVersion);
+
         for (const engine of document.querySelectorAll(
           '[data-engine].hidden'
         )) {
@@ -896,6 +908,20 @@ const comparisons = await getComparisons();
             engine.classList.add('hidden');
           }
         }
+      }
+
+      function getInitialSliderState(): string | undefined {
+        const urlParams = new URLSearchParams(location.search);
+        return urlParams.get('support');
+      }
+      const initialSliderState = getInitialSliderState();
+      if (initialSliderState) {
+        if (initialSliderState.includes('ie')) {
+          ieQuestion.checked = true;
+          ieMinVersion.value = initialSliderState.replace('ie', '');
+          versionBox.classList.remove('hidden');
+        }
+        updateEngines(initialSliderState);
       }
 
       ieQuestion.addEventListener('change', () => {


### PR DESCRIPTION
First pointed out in https://github.com/HubSpot/youmightnotneedjquery/pull/248#issuecomment-1256677522. Re-adds the query parameter-based IE population.

Checks:
- Page loads to modern by default
- Pages with valid `ieX` support query parameter set the selector values, checks the IE support checkbox, and updates the displayed engine
- Toggling the IE support checkbox removes the query parameter
- Changing the IE slider changes the query parameter