### PR TITLE
Show navbar on all screen widths

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -26,7 +26,7 @@ const comparisons = await getComparisons();
   <body>
     <div class="main-wrapper">
       <input id="sidebar-toggle" type="checkbox" />
-      <nav id="mobile-navbar">
+      <nav id="navbar">
         <label id="sidebar-toggle-label" for="sidebar-toggle">
           <span></span>
         </label>
@@ -269,9 +269,11 @@ const comparisons = await getComparisons();
     </style>
 
     <style lang="scss">
+      $border-color: #eee;
       $sidebar-width: 300px;
       $sidebar-collapsed-screen-width: 828px;
-      $mobile-navbar-height: 60px;
+      $navbar-height: 60px;
+      $transition-duration: 0.25s;
 
       ::placeholder {
         color: rgba(0, 0, 0, 0.5);
@@ -281,7 +283,7 @@ const comparisons = await getComparisons();
         scroll-behavior: smooth;
 
         @media screen and (max-width: $sidebar-collapsed-screen-width) {
-          scroll-padding-top: $mobile-navbar-height;
+          scroll-padding-top: $navbar-height;
         }
       }
 
@@ -309,6 +311,10 @@ const comparisons = await getComparisons();
         left: 0;
       }
 
+      #sidebar-toggle:checked ~ #main-content {
+        margin-left: $sidebar-width;
+      }
+
       #sidebar-toggle-label {
         position: fixed;
         z-index: 2;
@@ -326,7 +332,7 @@ const comparisons = await getComparisons();
           width: 100%;
           height: 2px;
           background-color: #333;
-          transition-duration: 0.25s;
+          transition-duration: $transition-duration;
         }
 
         span::before {
@@ -340,7 +346,7 @@ const comparisons = await getComparisons();
         }
       }
 
-      #sidebar-toggle:checked + #mobile-navbar {
+      #sidebar-toggle:checked + #navbar {
         #sidebar-toggle-label span {
           transform: rotate(45deg);
           &::before {
@@ -354,19 +360,15 @@ const comparisons = await getComparisons();
         }
       }
 
-      #mobile-navbar {
+      #navbar {
         position: fixed;
         left: 0;
         right: 0;
         background-color: #fff;
-        height: $mobile-navbar-height;
-        border-bottom: 1px solid #eee;
+        height: $navbar-height;
+        border-bottom: 1px solid $border-color;
         z-index: 1;
-        display: none;
-
-        @media screen and (max-width: $sidebar-collapsed-screen-width) {
-          display: block;
-        }
+        display: block;
       }
 
       #sidebar {
@@ -380,12 +382,13 @@ const comparisons = await getComparisons();
         bottom: 0;
         overflow: auto;
         padding: 2em;
-        transition-duration: 0.25s;
+        transition-duration: $transition-duration;
+        margin-top: $navbar-height;
+        border-right: 1px solid $border-color;
+        left: -100%;
 
         @media screen and (max-width: $sidebar-collapsed-screen-width) {
           width: 100%;
-          left: -100%;
-          margin-top: $mobile-navbar-height;
         }
 
         ul {
@@ -430,11 +433,13 @@ const comparisons = await getComparisons();
         align-items: center;
         display: flex;
         flex-direction: column;
-        margin-left: $sidebar-width;
+        margin-left: 0;
+        margin-top: $navbar-height;
+        transition-duration: $transition-duration;
 
         @media screen and (max-width: $sidebar-collapsed-screen-width) {
           margin-left: 0;
-          margin-top: $mobile-navbar-height;
+          margin-top: $navbar-height;
         }
       }
 
@@ -998,12 +1003,19 @@ const comparisons = await getComparisons();
       const activeCategoryOrComparison = findActiveCategoryOrComparison();
       markSidebarAnchorActive(activeCategoryOrComparison);
 
+      const MOBILE_WIDTH = 828;
       const sidebar: HTMLDivElement = document.querySelector('#sidebar');
+      const sidebarToggle: HTMLInputElement =
+        document.querySelector('#sidebar-toggle');
+      sidebarToggle.checked = window.innerWidth >= MOBILE_WIDTH;
       sidebar.querySelectorAll('a').forEach((el) => {
         el.addEventListener('click', () => {
           const sidebarToggle: HTMLInputElement =
             document.querySelector('#sidebar-toggle');
-          sidebarToggle.checked = false;
+          // Only close the sidebar automatically on mobile
+          if (window.innerWidth < MOBILE_WIDTH) {
+            sidebarToggle.checked = false;
+          }
         });
       });
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -433,11 +433,6 @@ const comparisons = await getComparisons();
         margin-left: 0;
         margin-top: $navbar-height;
         transition-duration: $transition-duration;
-
-        @media screen and (max-width: $sidebar-collapsed-screen-width) {
-          margin-left: 0;
-          margin-top: $navbar-height;
-        }
       }
 
       #top {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -280,11 +280,27 @@ const comparisons = await getComparisons();
       }
 
       html {
+        --background-color-1: #fff;
+        --background-color-2: #eee;
+        --border-color: #eee;
+        --navbar-toggle: #333;
+        --text-color: #000;
+
+        &.dark-mode {
+          --background-color-1: #181a1b;
+          --background-color-2: #222426;
+          --border-color: #0e1026;
+          --navbar-toggle: #ddd;
+          --text-color: #fff;
+        }
+
         scroll-behavior: smooth;
         scroll-padding-top: $navbar-height;
       }
 
       body {
+        background-color: var(--background-color-1);
+        color: var(--text-color);
         font-family: system-ui, sans-serif;
         line-height: 1.5;
         display: flex;
@@ -328,7 +344,7 @@ const comparisons = await getComparisons();
           position: absolute;
           width: 100%;
           height: 2px;
-          background-color: #333;
+          background-color: var(--navbar-toggle);
           transition-duration: $transition-duration;
         }
 
@@ -361,16 +377,16 @@ const comparisons = await getComparisons();
         position: fixed;
         left: 0;
         right: 0;
-        background-color: #fff;
+        background-color: var(--background-color-1);
         height: $navbar-height;
-        border-bottom: 1px solid $border-color;
+        border-bottom: 1px solid var(--border-color);
         z-index: 1;
         display: block;
       }
 
       #sidebar {
         flex: 0;
-        background-color: #fff;
+        background-color: var(--background-color-1);
         z-index: 1;
         width: $sidebar-width;
         position: fixed;
@@ -381,7 +397,7 @@ const comparisons = await getComparisons();
         padding: 2em;
         transition-duration: $transition-duration;
         margin-top: $navbar-height;
-        border-right: 1px solid $border-color;
+        border-right: 1px solid var(--border-color);
         left: -100%;
 
         @media screen and (max-width: $sidebar-collapsed-screen-width) {
@@ -720,7 +736,7 @@ const comparisons = await getComparisons();
             }
 
             &.even {
-              background: #eee;
+              background: var(--background-color-2);
 
               :global(.code) {
                 background: white;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -281,10 +281,7 @@ const comparisons = await getComparisons();
 
       html {
         scroll-behavior: smooth;
-
-        @media screen and (max-width: $sidebar-collapsed-screen-width) {
-          scroll-padding-top: $navbar-height;
-        }
+        scroll-padding-top: $navbar-height;
       }
 
       body {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -999,6 +999,7 @@ const comparisons = await getComparisons();
       const sidebar: HTMLDivElement = document.querySelector('#sidebar');
       const sidebarToggle: HTMLInputElement =
         document.querySelector('#sidebar-toggle');
+      // Default the sidebar toggle open when on larger screens
       sidebarToggle.checked = window.innerWidth >= MOBILE_WIDTH;
       sidebar.querySelectorAll('a').forEach((el) => {
         el.addEventListener('click', () => {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -280,27 +280,11 @@ const comparisons = await getComparisons();
       }
 
       html {
-        --background-color-1: #fff;
-        --background-color-2: #eee;
-        --border-color: #eee;
-        --navbar-toggle: #333;
-        --text-color: #000;
-
-        &.dark-mode {
-          --background-color-1: #181a1b;
-          --background-color-2: #222426;
-          --border-color: #0e1026;
-          --navbar-toggle: #ddd;
-          --text-color: #fff;
-        }
-
         scroll-behavior: smooth;
         scroll-padding-top: $navbar-height;
       }
 
       body {
-        background-color: var(--background-color-1);
-        color: var(--text-color);
         font-family: system-ui, sans-serif;
         line-height: 1.5;
         display: flex;
@@ -344,7 +328,7 @@ const comparisons = await getComparisons();
           position: absolute;
           width: 100%;
           height: 2px;
-          background-color: var(--navbar-toggle);
+          background-color: #333;
           transition-duration: $transition-duration;
         }
 
@@ -377,16 +361,16 @@ const comparisons = await getComparisons();
         position: fixed;
         left: 0;
         right: 0;
-        background-color: var(--background-color-1);
+        background-color: #fff;
         height: $navbar-height;
-        border-bottom: 1px solid var(--border-color);
+        border-bottom: 1px solid $border-color;
         z-index: 1;
         display: block;
       }
 
       #sidebar {
         flex: 0;
-        background-color: var(--background-color-1);
+        background-color: #fff;
         z-index: 1;
         width: $sidebar-width;
         position: fixed;
@@ -397,7 +381,7 @@ const comparisons = await getComparisons();
         padding: 2em;
         transition-duration: $transition-duration;
         margin-top: $navbar-height;
-        border-right: 1px solid var(--border-color);
+        border-right: 1px solid $border-color;
         left: -100%;
 
         @media screen and (max-width: $sidebar-collapsed-screen-width) {
@@ -736,7 +720,7 @@ const comparisons = await getComparisons();
             }
 
             &.even {
-              background: var(--background-color-2);
+              background: #eee;
 
               :global(.code) {
                 background: white;


### PR DESCRIPTION
Collapsing the sidebar on desktop is pretty useful with smaller windows, especially if the code blocks start to wrap. Also, the navbar prep is necessary to add buttons to the top (like a dark mode toggle)