### PR TITLE
Issue with margins

### DIFF
--- a/src/comparisons/elements/outer_height_with_margin/modern.js
+++ b/src/comparisons/elements/outer_height_with_margin/modern.js
@@ -1,11 +1,11 @@
 function outerHeight(el) {
   const style = getComputedStyle(el);
 
-  return (
-    el.getBoundingClientRect().height +
-    parseFloat(style.getPropertyValue('marginTop')) +
-    parseFloat(style.getPropertyValue('marginBottom'))
-  );
+	return (
+		el.getBoundingClientRect().height +
+		parseFloat(style.marginTop) +
+		parseFloat(style.marginBottom)
+	);
 }
 
 outerHeight(el);


### PR DESCRIPTION
The CSSStyleDeclaration.getPropertyValue function returns declared values. This means that if the css uses margin shorthand instead of explicitly calling margin top and margin bottom, this function will fail, returning NaN values. Replacing this with the attributes themselves will, instead, return the computed values. Happy New Year :)