### PR TITLE
Fix incorrect property access on outer width calculation

### DIFF
--- a/src/comparisons/elements/outer_height_with_margin/modern.js
+++ b/src/comparisons/elements/outer_height_with_margin/modern.js
@@ -1,11 +1,11 @@
 function outerHeight(el) {
   const style = getComputedStyle(el);
 
-	return (
-		el.getBoundingClientRect().height +
-		parseFloat(style.marginTop) +
-		parseFloat(style.marginBottom)
-	);
+  return (
+    el.getBoundingClientRect().height +
+    parseFloat(style.marginTop) +
+    parseFloat(style.marginBottom)
+  );
 }
 
 outerHeight(el);

--- a/src/comparisons/elements/outer_width_with_margin/modern.js
+++ b/src/comparisons/elements/outer_width_with_margin/modern.js
@@ -3,8 +3,8 @@ function outerWidth(el) {
 
   return (
     el.getBoundingClientRect().width +
-    parseFloat(style.getPropertyValue('marginLeft')) +
-    parseFloat(style.getPropertyValue('marginRight'))
+    parseFloat(style.marginLeft) +
+    parseFloat(style.marginRight)
   );
 }
 


### PR DESCRIPTION
Per the changes made in #317, also copying the fix to our outer width function. Attempting to access a property that is not defined yields an empty string, which is NaN when fed to `parseFloat`