### PR TITLE
Fix ordering of parents replacement

### DIFF
--- a/src/comparisons/elements/parents/ie9.js
+++ b/src/comparisons/elements/parents/ie9.js
@@ -2,7 +2,7 @@ function parents(el, selector) {
   var parents = [];
   while ((el = el.parentNode) && el !== document) {
     // See "Matches Selector" above
-    if (!selector || matches(el, selector)) parents.unshift(el);
+    if (!selector || matches(el, selector)) parents.push(el);
   }
   return parents;
 }

--- a/src/comparisons/elements/parents/modern.js
+++ b/src/comparisons/elements/parents/modern.js
@@ -1,7 +1,7 @@
 function parents(el, selector) {
   const parents = [];
   while ((el = el.parentNode) && el !== document) {
-    if (!selector || el.matches(selector)) parents.unshift(el);
+    if (!selector || el.matches(selector)) parents.push(el);
   }
   return parents;
 }


### PR DESCRIPTION
jQuery traversing uses `push`, not `unshift` when adding elements to the parents array.

Source: https://github.com/jquery/jquery/blob/a684e6ba836f7c553968d7d026ed7941e1a612d8/src/traversing/var/dir.js

Use in `parents` definition: https://github.com/jquery/jquery/blob/a684e6ba836f7c553968d7d026ed7941e1a612d8/src/traversing.js#L115