### PR TITLE
Fix prev and next to return early when given selector

### DIFF
--- a/src/comparisons/elements/next/modern.js
+++ b/src/comparisons/elements/next/modern.js
@@ -1,11 +1,8 @@
 function next(el, selector) {
   if (selector) {
-    let next = el.nextElementSibling;
-    while (next) {
-      if (next.matches(selector)) {
-        return next;
-      }
-      next = next.nextElementSibling;
+    const next = el.nextElementSibling;
+    if (next && next.matches(selector)) {
+      return next;
     }
     return undefined;
   } else {

--- a/src/comparisons/elements/prev/modern.js
+++ b/src/comparisons/elements/prev/modern.js
@@ -1,11 +1,8 @@
 function prev(el, selector) {
   if (selector) {
-    let previous = el.previousElementSibling;
-    while (previous) {
-      if (previous.matches(selector)) {
-        return previous;
-      }
-      previous = previous.previousElementSibling;
+    const prev = el.previousElementSibling;
+    if (prev && prev.matches(selector)) {
+      return prev;
     }
     return undefined;
   } else {


### PR DESCRIPTION
As @ianthedev has pointed out [here](https://github.com/HubSpot/youmightnotneedjquery/issues/324#issuecomment-1411918030), the implementation for `prev` and `next` are slightly different than the jQuery specs:
- `prev`: "Get the immediately preceding sibling of each element in the set of matched elements. If a selector is provided, it retrieves the previous sibling only if it matches that selector."
- `next`: "Get the immediately following sibling of each element in the set of matched elements. If a selector is provided, it retrieves the next sibling only if it matches that selector."

Our implementation should not be iterating over elements but instead returning early