### PR TITLE
fix deepExtend - problems for long levels

### DIFF
--- a/src/comparisons/utils/deep_extend/modern.js
+++ b/src/comparisons/utils/deep_extend/modern.js
@@ -11,6 +11,7 @@ function deepExtend(out, ...arguments_) {
     for (const [key, value] of Object.entries(obj)) {
       switch (Object.prototype.toString.call(value)) {
         case '[object Object]':
+          out[key] = out[key] || {};
           out[key] = deepExtend(out[key], value);
           break;
         case '[object Array]':


### PR DESCRIPTION
**before the change**:
```javascript
JSON.stringify( deepExtend({}, {'a': {c: [1,2,3]}} ) );
// {"a":{}}

JSON.stringify( deepExtend({}, {'a': {c: { d: 'd'}}} ) ) ; 
// '{"a":{}}'
```

**after the change**:
```javascript
JSON.stringify( deepExtend({}, {'a': {c: [1,2,3]}} ) ); 
// {"a":{"c":[1,2,3]}}

JSON.stringify( deepExtend({}, {'a': {c: { d: 'd'}}} ) ) ; 
//'{"a":{"c":{"d":"d"}}}'
```