### PR TITLE
Fix click area on sidebar toggle

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -315,7 +315,7 @@ const comparisons = await getComparisons();
       #sidebar-toggle-label {
         position: fixed;
         z-index: 2;
-        top: 28px;
+        top: 16px;
         left: 20px;
         width: 26px;
         height: 26px;
@@ -330,6 +330,7 @@ const comparisons = await getComparisons();
           height: 2px;
           background-color: #333;
           transition-duration: $transition-duration;
+          top: 50%;
         }
 
         span::before {


### PR DESCRIPTION
The click/tap area for our sidebar toggle is off by 50%. This PR corrects the offset of the rendered lines

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/10366495/235045764-2f85d258-f907-493c-b7ba-3ed2fbd64bd3.png)|![image](https://user-images.githubusercontent.com/10366495/235045556-61768c68-7850-4cd4-9c4b-1c8693652911.png)|
