### PR TITLE
Ensure return type on prev/next selectors is consistent

### DIFF
--- a/src/comparisons/elements/next/modern.js
+++ b/src/comparisons/elements/next/modern.js
@@ -1,13 +1,9 @@
 function next(el, selector) {
-  if (selector) {
-    const next = el.nextElementSibling;
-    if (next && next.matches(selector)) {
-      return next;
-    }
-    return undefined;
-  } else {
-    return el.nextElementSibling;
+  const nextEl = el.nextElementSibling;
+  if (!selector || (nextEl && nextEl.matches(selector))) {
+    return nextEl;
   }
+  return null;
 }
 
 next(el);

--- a/src/comparisons/elements/prev/modern.js
+++ b/src/comparisons/elements/prev/modern.js
@@ -1,13 +1,9 @@
 function prev(el, selector) {
-  if (selector) {
-    const prev = el.previousElementSibling;
-    if (prev && prev.matches(selector)) {
-      return prev;
-    }
-    return undefined;
-  } else {
-    return el.previousElementSibling;
+  const prevEl = el.previousElementSibling;
+  if (!selector || (prevEl && prevEl.matches(selector))) {
+    return prevEl;
   }
+  return null;
 }
 
 prev(el);


### PR DESCRIPTION
Addresses #341 

This PR consolidates the potentially ambiguous falsy return types into a singular `null` return type if no matching element exists when calling `prev` or `next`