### PR TITLE
Fix scrollLeft and scrollTop to work with non-windows

### DIFF
--- a/src/comparisons/elements/scroll_left/modern.js
+++ b/src/comparisons/elements/scroll_left/modern.js
@@ -1,11 +1,18 @@
 function scrollLeft(el, value) {
+  var win;
+  if (el.window === el) {
+    win = el;
+  } else if (el.nodeType === 9) {
+    win = el.defaultView;
+  }
+
   if (value === undefined) {
-    return el.pageXOffset;
+    return win ? win.pageXOffset : el.scrollLeft;
+  }
+
+  if (win) {
+    win.scrollTo(value, win.pageYOffset);
   } else {
-    if (el === window || el.nodeType === 9) {
-      el.scrollTo(value, el.pageYOffset);
-    } else {
-      el.pageXOffset = value;
-    }
+    el.scrollLeft = value;
   }
 }

--- a/src/comparisons/elements/scroll_top/modern.js
+++ b/src/comparisons/elements/scroll_top/modern.js
@@ -1,11 +1,18 @@
 function scrollTop(el, value) {
+  var win;
+  if (el.window === el) {
+    win = el;
+  } else if (el.nodeType === 9) {
+    win = el.defaultView;
+  }
+
   if (value === undefined) {
-    return el.pageYOffset;
+    return win ? win.pageYOffset : el.scrollTop;
+  }
+
+  if (win) {
+    win.scrollTo(win.pageXOffset, value);
   } else {
-    if (el === window || el.nodeType === 9) {
-      el.scrollTo(el.pageXOffset, value);
-    } else {
-      el.pageYOffset = value;
-    }
+    el.scrollTop = value;
   }
 }


### PR DESCRIPTION
Fixes #343 -- the original implementation only worked with window objects and not regular elements. In addition, it had a bug where nodes with type 9 (document nodes) didn't yield their `defaultView` property as the element to manipulate. This implementation is heavily inspired from jQuery source [here](https://github.com/jquery/jquery/blob/3.2.1/src/offset.js#L176-L191).