### PR TITLE
Remove bad event copy

### DIFF
--- a/src/comparisons/events/on/modern.js
+++ b/src/comparisons/events/on/modern.js
@@ -4,12 +4,7 @@ function addEventListener(el, eventName, eventHandler, selector) {
       if (!e.target) return;
       const el = e.target.closest(selector);
       if (el) {
-        const newEvent = Object.create(e, {
-          target: {
-            value: el
-          }
-        });
-        eventHandler.call(el, newEvent);
+        eventHandler.call(el, e);
       }
     };
     el.addEventListener(eventName, wrappedHandler);


### PR DESCRIPTION
**Related issue:**
As called out [here](https://github.com/HubSpot/youmightnotneedjquery/issues/316#issuecomment-1618012009), copying events without properly reconstructing the Event object will cause exceptions to be thrown.

**Further consideration:**
This patch is less-than-ideal because the vanilla JS implementation does not match jQuery's when it comes to setting the `currentTarget` property. jQuery's events [allow mutation](https://github.com/jquery/jquery/blob/4a13266efd262a92f05d86b71d715885de103e6d/src/event.js#L309) of `currentTarget`. We should try to find a simple way to proxy the getter of said property in a follow-up