### PR TITLE
Add invocation of ready function

### DIFF
--- a/src/comparisons/events/ready/ie8.js
+++ b/src/comparisons/events/ready/ie8.js
@@ -9,3 +9,4 @@ function ready(fn) {
     });
   }
 }
+ready(function () {});

--- a/src/comparisons/events/ready/ie9.js
+++ b/src/comparisons/events/ready/ie9.js
@@ -9,3 +9,4 @@ function ready(fn) {
     document.addEventListener('DOMContentLoaded', fn);
   }
 }
+ready(function () {});

--- a/src/comparisons/events/ready/modern.js
+++ b/src/comparisons/events/ready/modern.js
@@ -5,3 +5,4 @@ function ready(fn) {
     document.addEventListener('DOMContentLoaded', fn);
   }
 }
+ready(() => {});


### PR DESCRIPTION
The `ready` JQuery code is:

    $(document).ready(function () {});

Currently, the modern equivalent is listed as:

```
function ready(fn) {
  if (document.readyState !== 'loading') {
    fn();
  } else {
    document.addEventListener('DOMContentLoaded', fn);
  }
}
```

However, this isn't exactly equivalent, as the `ready` function does not get called. This pull request makes it equivalent to the JQuery code.