### PR TITLE
Add examples for animate() using Web Animations API

### DIFF
--- a/src/comparisons/effects/animate/jquery.js
+++ b/src/comparisons/effects/animate/jquery.js
@@ -1,0 +1,3 @@
+$(el).css({ width: '0%', 'height': '24px' })
+  .animate({ width: "90%" }, 1000)
+  .animate({ height: "400px" }, 1000);

--- a/src/comparisons/effects/animate/modern.js
+++ b/src/comparisons/effects/animate/modern.js
@@ -1,0 +1,8 @@
+await el.animate(
+    [{ 'width': '0%' }, { 'width': '90%' }],
+    { duration: 1000, easing: 'ease-in-out', fill: 'forwards' }
+).finished;
+await el.animate(
+    [{ 'height': '24px' }, { 'height': '400px' }],
+    { duration: 1000, easing: 'ease-in-out', fill: 'forwards' }
+).finished;


### PR DESCRIPTION
Add examples for `animate()` using Web Animations API. 

Unfortunately Web Animations API uses keyframe semantics, so it is not a 1-to-1 translation. 